### PR TITLE
fix(inbox): preview underlag via the inline document proxy

### DIFF
--- a/components/extensions/general/InvoiceInboxWorkspace.tsx
+++ b/components/extensions/general/InvoiceInboxWorkspace.tsx
@@ -752,19 +752,10 @@ export default function InvoiceInboxWorkspace(_props: WorkspaceComponentProps) {
       }
       const { data } = await res.json()
       if (docRequestRef.current !== request) return
-      const url: string | null = data?.download_url ?? null
-      // HTML mail underlag renders via the same-origin inline proxy: it
-      // serves text/html with a CSP sandbox header and guaranteed inline
-      // disposition. Other types keep the signed storage URL.
-      const effectiveUrl =
-        data?.mime_type === 'text/html' ? `/api/documents/${documentId}/inline` : url
-      if (!url) {
-        // The document row exists but no signed URL came back: still a load
-        // failure, not an absent underlag.
-        setDocState('error')
-        return
-      }
-      setDocUrl(effectiveUrl)
+      // Always preview via the same-origin inline proxy. Signed Storage URLs
+      // are served as Content-Disposition: attachment, which Chrome blocks in
+      // iframe/img with "Det här innehållet har blockerats".
+      setDocUrl(`/api/documents/${documentId}/inline`)
       setDocMime(data?.mime_type ?? null)
       setDocState('ready')
     } catch {
@@ -2289,7 +2280,7 @@ export function DocumentPreview({
       ) : (
         // PDF: iframe needs explicit height, frame fills the available pane.
         <div className="h-full w-full max-w-3xl bg-background rounded-lg border overflow-hidden">
-          <iframe src={docUrl} className="w-full h-full border-0" title="Underlag" />
+          <embed src={docUrl} type="application/pdf" className="w-full h-full border-0" title="Underlag" />
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- Inbox already proxied HTML underlag through `/api/documents/:id/inline` (same-origin, inline disposition, CSP sandbox). PDFs and images still used the signed Storage URL.
- Storage serves those as `Content-Disposition: attachment`, which Chrome blocks in iframe/img ("Det här innehållet har blockerats").
- Always preview via the inline proxy. Render PDF with `<embed>` so the browser PDF viewer is used instead of a blocked iframe.

## Test plan
- [ ] Open a PDF underlag in Dokumentinkorgen in Chrome: the preview renders, no "innehållet har blockerats".
- [ ] Open an image underlag: preview still works.
- [ ] Open an HTML mail underlag: still uses the sandboxed inline proxy.
- [ ] Missing/failed document still shows the existing error state.

Made with [Cursor](https://cursor.com)
