### PR TITLE
fix(enable-banking): stop paginating empty AIS continuation pages

### DIFF
--- a/extensions/general/enable-banking/lib/__tests__/api-client.test.ts
+++ b/extensions/general/enable-banking/lib/__tests__/api-client.test.ts
@@ -167,6 +167,31 @@ describe('api-client', () => {
 
       warnSpy.mockRestore()
     })
+
+    it('stops when a page is empty but still sends continuation_key', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      fetchSpy.mockImplementation(() => {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              transactions: [],
+              continuation_key: 'keep-going',
+            }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } }
+          )
+        )
+      })
+
+      const result = await getAllTransactions('acc-1', '2024-01-01', '2024-12-31')
+
+      expect(result).toHaveLength(0)
+      expect(fetchSpy).toHaveBeenCalledTimes(1)
+      expect(warnSpy).toHaveBeenCalledWith(
+        '[enable-banking] Empty page with continuation_key; stopping pagination',
+        expect.objectContaining({ accountUid: 'acc-1', page: 1 }),
+      )
+      warnSpy.mockRestore()
+    })
   })
 
   // -------------------------------------------------------------------------

--- a/extensions/general/enable-banking/lib/api-client.ts
+++ b/extensions/general/enable-banking/lib/api-client.ts
@@ -849,6 +849,18 @@ export async function getAllTransactions(
       break
     }
     if (!continuationKey) break
+    // Swedbank historic AIS (strategy=longest) returns empty pages plus a
+    // continuation_key while it prepares. Following that key used to spin
+    // MAX_PAGINATION_PAGES (~100) in seconds and ingest nothing. An empty
+    // page means this window has no more booked txs; the next cron picks up
+    // whatever the bank later materializes.
+    if (!(response.transactions && response.transactions.length)) {
+      console.warn('[enable-banking] Empty page with continuation_key; stopping pagination', {
+        accountUid,
+        page,
+      })
+      break
+    }
   }
 
   return allTransactions
@@ -1039,6 +1051,15 @@ export async function getAllTransactionsWithRaw(
       break
     }
     if (!continuationKey) break
+    // See getAllTransactions: empty+continuation is not more data, it is
+    // an unprepared historic window (Swedbank). Stop instead of spinning.
+    if (!(data.transactions && data.transactions.length)) {
+      console.warn('[enable-banking] Empty page with continuation_key; stopping pagination', {
+        accountUid,
+        page,
+      })
+      break
+    }
   }
 
   return { transactions: allTransactions, rawPages }


### PR DESCRIPTION
## Summary
- `getAllTransactions` / `getAllTransactionsWithRaw` follow `continuation_key` up to 100 pages. That is correct when pages have transactions.
- Swedbank historic AIS (`strategy=longest`) can return an **empty** page plus a continuation key while it prepares. Following that key spun 100 empty pages in ~25s and ingested nothing.
- Stop when a page has a continuation key but no transactions. Keep `strategy=longest` (required by existing tests and other ASPSPs). The next cron picks up whatever the bank later materializes.
- Do not remove `strategy=longest` globally.

## Test plan
- [ ] `npx vitest run extensions/general/enable-banking/lib/__tests__/api-client.test.ts`
- [ ] New case: empty `transactions` + `continuation_key` → 1 fetch, not 100.
- [ ] Existing cap test still stops at 100 when every page has a transaction.
- [ ] Existing `strategy=longest` / no-strategy fallback tests still pass.

Made with [Cursor](https://cursor.com)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction retrieval when an empty page includes a continuation marker.
  * Pagination now stops promptly instead of making unnecessary follow-up requests.
  * Prevents repeated empty requests while preserving transactions retrieved in later syncs.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->