### PR TITLE
fix(cash-accounts): rebind transactions when remapping a PSD2 ledger

### DIFF
--- a/lib/cash-accounts/__tests__/service.test.ts
+++ b/lib/cash-accounts/__tests__/service.test.ts
@@ -475,6 +475,8 @@ interface UpsertStub {
   rpcCalls: Array<{ fn: string; args: Record<string, unknown> }>
   /** .eq() filters applied to the linked-transactions probe. */
   transactionFilters: Array<{ col: string; value: unknown }>
+  /** Rebind writes from the overflow duplicate onto the promoted row. */
+  txRebinds: Array<Record<string, unknown>>
 }
 
 function makeUpsertStub(partial: Partial<UpsertStub> = {}): UpsertStub {
@@ -484,6 +486,7 @@ function makeUpsertStub(partial: Partial<UpsertStub> = {}): UpsertStub {
     upserts: [],
     rpcCalls: [],
     transactionFilters: [],
+    txRebinds: [],
     ...partial,
   }
 }
@@ -520,6 +523,18 @@ function makeUpsertSupabase(stub: UpsertStub) {
               error: null,
             }),
           ),
+          update: vi.fn((payload: Record<string, unknown>) => {
+            stub.txRebinds.push(payload)
+            const eqChain = {
+              eq: vi.fn((col: string, value: unknown) => {
+                stub.transactionFilters.push({ col, value })
+                return eqChain
+              }),
+              then: (onFulfilled: (v: { error: null }) => unknown) =>
+                Promise.resolve({ error: null }).then(onFulfilled),
+            }
+            return eqChain
+          }),
         }
         return chain
       }
@@ -702,7 +717,7 @@ describe('upsertFromPsd2', () => {
     expect(stub.rpcCalls).toHaveLength(0)
   })
 
-  it('demotes (not deletes) a duplicate that has linked transactions', async () => {
+  it('rebinds linked transactions then deletes the overflow duplicate', async () => {
     const stub = makeUpsertStub({
       holder: { id: 'row-old', bank_connection_id: 'conn-old' },
       connections: [{ id: 'conn-old', status: 'revoked' }],
@@ -711,15 +726,11 @@ describe('upsertFromPsd2', () => {
     })
     await upsertFromPsd2(makeUpsertSupabase(stub), 'c1', UPSERT_INPUT)
 
-    expect(stub.deletes).toHaveLength(0)
-    expect(stub.updates).toHaveLength(2)
-    // First write releases the duplicate's PSD2 binding, preserving the row
-    // (and its transactions.cash_account_id links) as a manual account.
-    expect(stub.updates[0].id).toBe('row-dup')
-    expect(stub.updates[0].payload).toEqual({ bank_connection_id: null, external_uid: null })
-    // Second write promotes the holder.
-    expect(stub.updates[1].id).toBe('row-old')
-    expect(stub.updates[1].payload).toMatchObject({ bank_connection_id: 'conn-new' })
+    expect(stub.txRebinds).toEqual([{ cash_account_id: 'row-old' }])
+    expect(stub.deletes).toEqual(['row-dup'])
+    expect(stub.updates).toHaveLength(1)
+    expect(stub.updates[0].id).toBe('row-old')
+    expect(stub.updates[0].payload).toMatchObject({ bank_connection_id: 'conn-new' })
   })
 
   it('scopes the duplicate linked-transactions probe by company (service-role defense in depth)', async () => {
@@ -768,9 +779,8 @@ describe('upsertFromPsd2', () => {
     })
     await upsertFromPsd2(makeUpsertSupabase(stub), 'c1', UPSERT_INPUT)
 
-    expect(stub.deletes).toHaveLength(0)
-    expect(stub.updates[0].id).toBe('row-dup')
-    expect(stub.updates[0].payload).toEqual({ bank_connection_id: null, external_uid: null })
+    expect(stub.deletes).toEqual(['row-dup'])
+    expect(stub.txRebinds).toEqual([{ cash_account_id: 'row-old' }])
     expect(stub.rpcCalls).toEqual([
       {
         fn: 'set_cash_account_primary',

--- a/lib/cash-accounts/service.ts
+++ b/lib/cash-accounts/service.ts
@@ -540,10 +540,10 @@ export async function upsertFromPsd2(
     const typedOwn = ownRow as { id: string; is_primary: boolean } | null
     let transferPrimary = false
     if (typedOwn) {
-      // With linked transactions the duplicate is demoted to a plain manual
-      // row (deleting it would SET NULL those transactions' cash_account_id
-      // links). Without any, it is a leftover mirror from the broken reconnect
-      // and is deleted outright so its overflow slot frees up.
+      // With linked transactions the duplicate used to be demoted to a
+      // manual leftover so delete would not SET NULL cash_account_id.
+      // That left booking on the overflow ledger after remap. Rebind onto
+      // the promoted row, then delete the duplicate in both cases.
       const { data: linkedTx, error: linkedTxError } = await supabase
         .from('transactions')
         .select('id')
@@ -562,25 +562,28 @@ export async function upsertFromPsd2(
       }
 
       if ((linkedTx ?? []).length > 0) {
-        const { error: demoteError } = await supabase
-          .from('cash_accounts')
-          .update({ bank_connection_id: null, external_uid: null })
-          .eq('id', typedOwn.id)
-        if (demoteError) {
-          throw new Error(`cash_accounts upsert failed: ${demoteError.message}`)
-        }
-      } else {
-        const { error: deleteError } = await supabase
-          .from('cash_accounts')
-          .delete()
-          .eq('id', typedOwn.id)
-        if (deleteError) {
-          throw new Error(`cash_accounts upsert failed: ${deleteError.message}`)
+        // The overflow row still holds the imported bank txs. Demoting it to a
+        // manual leftover left categorize/booking on the old ledger (1931)
+        // after the user mapped the same IBAN to 1930. Rebind first so
+        // delete cannot SET NULL cash_account_id (ON DELETE SET NULL).
+        const { error: rebindError } = await supabase
+          .from('transactions')
+          .update({ cash_account_id: promotableRowId })
+          .eq('company_id', companyId)
+          .eq('cash_account_id', typedOwn.id)
+        if (rebindError) {
+          throw new Error(`cash_accounts upsert failed: ${rebindError.message}`)
         }
       }
-      // A primary duplicate must hand the flag to the promoted row either way:
-      // deleted, it would leave the __PRIMARY_SEK__ sentinel unresolvable;
-      // demoted, the sentinel would keep resolving to the stale manual row.
+      const { error: deleteError } = await supabase
+        .from('cash_accounts')
+        .delete()
+        .eq('id', typedOwn.id)
+      if (deleteError) {
+        throw new Error(`cash_accounts upsert failed: ${deleteError.message}`)
+      }
+      // A primary duplicate must hand the flag to the promoted row:
+      // deleted, it would leave the __PRIMARY_SEK__ sentinel unresolvable.
       transferPrimary = typedOwn.is_primary
     }
 


### PR DESCRIPTION
## Summary
- `upsertFromPsd2` could overflow onto a second cash account (e.g. 1931) when 1930 was already taken. Remapping the same IBAN to 1930 **demoted** the overflow row (cleared `bank_connection_id`) instead of moving the imported txs.
- AI booking reads `transactions.cash_account_id` → `cash_accounts.ledger_account`, so those rows kept proposing 1931 after the UI showed 1930.
- Rebind `cash_account_id` onto the promoted row, then delete the duplicate. Rebind first so `ON DELETE SET NULL` cannot orphan the txs. Delete even when there are no linked txs (same leftover-mirror cleanup as before).

## Test plan
- [ ] `npx vitest run lib/cash-accounts/__tests__/service.test.ts`
- [ ] Duplicate with linked txs: txs move to the promoted cash account; overflow row is deleted (not demoted to a manual leftover).
- [ ] Duplicate with no txs: overflow row is still deleted.
- [ ] Primary flag still transfers to the promoted row.

Made with [Cursor](https://cursor.com)
