### PR TITLE
perf(agent): drop extended thinking on /chat and the empty auto-fire on open (audit quick wins)

### DIFF
--- a/components/agent/AgentChat.tsx
+++ b/components/agent/AgentChat.tsx
@@ -296,19 +296,21 @@ export default function AgentChat({
     // the composer is already replaced by the upgrade note.
     if (!hasAi) return
 
-    // Seed-message path: render the user's pre-baked starter in the timeline
-    // and send it as the first turn's user_message (skips intent.capture +
-    // promptTemplate). Empty seed runs the normal capture-driven flow.
+    // Seed-message path: the user arrived with a pre-baked starter (e.g. an
+    // "ask about this" button), an explicit intent to ask something: render it
+    // and send it as the first turn's user_message. This still auto-fires
+    // because the user chose to.
+    //
+    // No EMPTY auto-fire (audit 2026-08-18): opening /chat with nothing to say
+    // used to fire a full turn to generate a greeting, and 27-75% of those
+    // conversations were then never typed in: a model call and a wait for a
+    // greeting nobody asked for. The chat now opens ready for input; the first
+    // turn runs when the user actually sends something.
     if (seedUserMessage && seedUserMessage.trim().length > 0) {
       setMessages([{ role: 'user', text: seedUserMessage.trim() }])
       void startTurn({
         conversationId: initialConversationId ?? null,
         userMessage: seedUserMessage.trim(),
-      })
-    } else {
-      void startTurn({
-        conversationId: initialConversationId ?? null,
-        userMessage: '',
       })
     }
     return () => {

--- a/lib/agent/intents/general-help.ts
+++ b/lib/agent/intents/general-help.ts
@@ -1,5 +1,5 @@
 import { defineAgentIntent } from './types'
-import { SONNET_MODEL, EFFORT_STANDARD } from '@/lib/agent/composer/client'
+import { SONNET_MODEL } from '@/lib/agent/composer/client'
 import { renderAgentGroundRules } from './shared-rules'
 
 // general.help: always-present "Fråga min assistent" from the top nav.
@@ -94,11 +94,11 @@ export const generalHelp = defineAgentIntent<GeneralHelpArgs, GeneralHelpCapture
 
   model: SONNET_MODEL,
 
-  // Reason before answering: this is the broad chat surface where the agent
-  // answered regulatory questions from memory and narrated its steps. Thinking
-  // moves the reasoning into its own channel so the visible reply is a single
-  // consolidated answer.
-  thinking: { effort: EFFORT_STANDARD },
+  // No extended thinking on the broad /chat surface (audit 2026-08-18): it was
+  // the single biggest latency source here, adaptive thinking is unavailable on
+  // the OpenAI-compatible/local backends this assistant is moving to, and the
+  // ground rules already forbid answering regulatory questions from memory. The
+  // reply is a single consolidated answer either way.
 
   capture: async ({ route }) => ({ route: route ?? null }),
 


### PR DESCRIPTION
## Why

WS1 **rip track, RIP-1** (your AI surface audit, 2026-08-18). Two independent, low-risk quick wins that trim the heavy chat runtime ahead of the full rip and align it with the local/OpenAI-compatible backends the assistant is moving to. Off `main` (no dependency on the AI-provider PRs).

## What
- **`general.help` no longer runs adaptive thinking.** It was the single biggest latency source on the broad `/chat` surface; adaptive thinking doesn't exist on OpenAI-compatible/local backends; and the ground rules already forbid answering regulatory questions from memory. Backend-only change.
- **`AgentChat` no longer auto-fires an empty first turn on open.** Opening `/chat` with nothing to say spent a model call generating a greeting, and per the audit 27-75% of those conversations were never typed in. The explicit **seed-message path** (an "ask about this" starter the user chose) still fires; the empty case opens ready for input.

## Please review the one visible change
The auto-fire change is **visible** — the chat opens without an auto-greeting. There are no component tests for `AgentChat` (Vitest scope is `lib/` + `app/api/`), so **please eyeball `/chat` open on the preview before merging** (per the standing UI sign-off rule). Everything else is backend and tested.

## Verification
- `general.help` read-only + redirect guards and the `run-turn` thinking guards unchanged and green; `lib/agent` suite green; `tsc`, `check:guards`, `check:lint` clean. No migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Empty chat sessions no longer automatically send an empty message or start an unnecessary agent turn.
  * Chat sessions now begin with a response only when an initial message is provided.

* **Improvements**
  * General help responses now use a streamlined single-response experience without extended thinking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->