### PR TITLE
docs(self-host): model-agnostic AI coverage boundary

### DIFF
--- a/docs/SELF-HOSTING.md
+++ b/docs/SELF-HOSTING.md
@@ -219,7 +219,7 @@ AWS_REGION=eu-north-1   # default
 
 Set both static AWS keys explicitly. The AI assistant's client can fall back to the standard AWS credential provider chain (instance profile, IRSA) when they are absent, but document extraction requires `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` and silently returns empty results without them.
 
-**Option 3: any OpenAI-compatible endpoint.** Any server that implements the chat-completions API: a Swedish inference provider for a fully sovereign deployment, or a **local model** on the same machine (llama.cpp's `server`, Ollama's `/v1`, LM Studio, vLLM). Document extraction (receipts, invoices, HTML mail invoices) and the single-call assistant (`/api/agent/ask`) run here on any provider; the older streaming chat panel is being replaced by that single-call surface.
+**Option 3: any OpenAI-compatible endpoint.** Any server that implements the chat-completions API: a Swedish inference provider for a fully sovereign deployment, or a **local model** on the same machine (llama.cpp's `server`, Ollama's `/v1`, LM Studio, vLLM). Document extraction (receipts, invoices, HTML mail invoices), the assistant's question-and-answer (on both `/chat` and the docked assistant sheet, via `/api/agent/ask`), and one-tap transaction categorization run here on any provider. A set of specialized conversational flows still needs an Anthropic-family backend; see **What runs on any model** below.
 
 ```bash
 AI_BASE_URL=http://localhost:11434/v1   # the endpoint's OpenAI-compatible base URL (here: a local Ollama)
@@ -234,6 +234,21 @@ Three things about such endpoints are declared rather than probed, because the a
 - `AI_VISION=false` says the configured model cannot read images. Images and PDFs are then skipped honestly (the inbox row lands with the empty skeleton and the "AI-tolkning kördes inte" hint) instead of failing with a 400 on every upload; HTML mail invoices still extract as text on any model.
 - `AI_PDF_MODE` defaults to `rasterize` here: most such endpoints have no PDF input, so the first `AI_PDF_MAX_PAGES` pages (default 4) are rendered to images with poppler's `pdftoppm`, which the self-host image installs (`apk add poppler-utils`, the only system package beyond the base image; page images are written to `/tmp`, a tmpfs in `docker-compose.yml`). If the binary is missing, PDFs are skipped with `pdf_rasterizer_missing` rather than failing; `AI_PDF_RASTERIZER_BIN` points at a non-standard install. A provider that accepts the OpenAI `file` content part can use `AI_PDF_MODE=native`.
 - `AI_STRICT_JSON=true` asks for `response_format: json_schema` on providers that enforce it. The default (JSON answered in prose, then parsed and validated) works on every model and is what hosted runs.
+
+#### What runs on any model
+
+Most AI surfaces run on any of the three backends above, an OpenAI-compatible or local model included:
+
+- **Document extraction**: receipts, invoices, and HTML mail invoices.
+- **The AI assistant's question-and-answer**, on both `/chat` and the docked assistant sheet (`/api/agent/ask`), including its read-only ledger tools.
+- **One-tap transaction categorization** (`/api/agent/categorize`): the deterministic-candidates then model-select cascade shown on the transactions page.
+
+A few **specialized conversational flows** still run on the older streaming runtime (`/api/agent/invoke`), which requires an Anthropic-family model (AWS Bedrock or the direct Anthropic API). On an OpenAI-compatible or local backend these specific actions return `503`; everything above keeps working. They are:
+
+- **Operation-staging flows** (they draft a change for you to approve): the invoice-inbox "Fraga assistenten" categorize, bulk-book, invoice draft, supplier-invoice review, and verifikat draft.
+- **Context-bound assistant helpers**: VAT review, KPI explanation, settings help, the bokslut step-through, and onboarding.
+
+Migrating these to the single-call surface, so a fully local deployment covers them too, is tracked in [#1800](https://github.com/erp-mafia/accounted/issues/1800).
 
 Optional model overrides, in any setup:
 


### PR DESCRIPTION
Documents which AI flows run on **any** configured backend (an OpenAI-compatible / local model included) versus the specialized flows that still need an **Anthropic-family** backend, so a self-hoster choosing their own model knows exactly what to expect.

- **Any model**: assistant Q&A on both `/chat` and the docked sheet (`/api/agent/ask`), document extraction, one-tap transaction categorization (`/api/agent/categorize`).
- **Anthropic-family only** (503 elsewhere): the operation-staging conversational flows (inbox categorize, bulk-book, invoice draft, supplier-invoice review, verifikat draft) and the context-bound helpers (VAT review, KPI, settings, bokslut, onboarding).

The remaining migration to make those local-capable too is tracked in #1800. Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated AI backend documentation to describe support for one-tap transaction categorization and both assistant interfaces.
  * Clarified which conversational features require Anthropic-family backends.
  * Documented the `503` response behavior when unsupported backends are used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->