### PR TITLE
fix(providers): serve local rate-limiter waiters in arrival order

### DIFF
--- a/lib/providers/__tests__/rate-limiter.test.ts
+++ b/lib/providers/__tests__/rate-limiter.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { TokenBucketRateLimiter } from '../rate-limiter';
+
+/**
+ * The local (no-Upstash) limiter must serve waiters in arrival order. Two
+ * callers that both find the bucket empty used to set their own timeouts
+ * that expired at the same instant; which woke first was platform-dependent,
+ * which made "open invoices are requested before paid ones" (hydrateInvoices)
+ * flip on CI while holding locally.
+ */
+describe('TokenBucketRateLimiter (local fallback)', () => {
+  beforeEach(() => {
+    vi.stubEnv('UPSTASH_REDIS_REST_URL', '');
+    vi.stubEnv('UPSTASH_REDIS_REST_TOKEN', '');
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllEnvs();
+  });
+
+  it('grants tokens immediately while the bucket has them', async () => {
+    const limiter = new TokenBucketRateLimiter({ maxRequests: 2, windowMs: 1000 });
+    await expect(limiter.acquire()).resolves.toBeUndefined();
+    await expect(limiter.acquire()).resolves.toBeUndefined();
+  });
+
+  it('serves waiters in arrival order once the bucket is empty', async () => {
+    const limiter = new TokenBucketRateLimiter({ maxRequests: 1, windowMs: 1000 });
+    await limiter.acquire(); // bucket empty
+
+    const order: string[] = [];
+    const a = limiter.acquire().then(() => order.push('a'));
+    const b = limiter.acquire().then(() => order.push('b'));
+    const c = limiter.acquire().then(() => order.push('c'));
+
+    await vi.advanceTimersByTimeAsync(5000);
+    await Promise.all([a, b, c]);
+    expect(order).toEqual(['a', 'b', 'c']);
+  });
+});

--- a/lib/providers/rate-limiter.ts
+++ b/lib/providers/rate-limiter.ts
@@ -78,7 +78,22 @@ export class TokenBucketRateLimiter {
     }
   }
 
-  private async acquireLocal(): Promise<void> {
+  // Local waiters are served in arrival order. Two callers that both find the
+  // bucket empty would otherwise race on timer tie-breaking: their timeouts
+  // expire at the same instant from different timer lists, and which wakes
+  // first is platform-dependent. Callers rely on "started first, requested
+  // first" (hydrateInvoices serves open invoices before paid ones), so the
+  // queue makes that guarantee hold without changing the rate.
+  private localQueue: Promise<void> = Promise.resolve();
+
+  private acquireLocal(): Promise<void> {
+    const turn = this.localQueue.then(() => this.acquireLocalInOrder());
+    // Keep the chain alive even if a turn rejects (nothing throws today).
+    this.localQueue = turn.catch(() => undefined);
+    return turn;
+  }
+
+  private async acquireLocalInOrder(): Promise<void> {
     this.refill();
     if (this.tokens > 0) {
       this.tokens--;


### PR DESCRIPTION
## Summary

`lib/providers/__tests__/hydrate-invoices.test.ts > requests the OPEN invoice before the paid one` failed twice on #1817's CI (and passes locally 6/6): two callers that both find the in-memory token bucket empty each set their own `setTimeout`; the timeouts expire at the same instant from different timer lists, and which wakes first is platform-dependent. `hydrateInvoices` relies on "started first, requested first" to serve open invoices before paid ones.

Fix: the local (no-Upstash) `acquire()` path serializes waiters through a promise queue, so arrival order is service order. The rate is unchanged; the Upstash path is untouched.

## Verification

- New `lib/providers/__tests__/rate-limiter.test.ts` (fake timers): three waiters on an empty bucket resolve a, b, c.
- `hydrate-invoices.test.ts` still passes; eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved local rate limiting so queued requests are processed in arrival order.
  * Prevented concurrent requests from racing when waiting for available capacity.

* **Tests**
  * Added coverage for immediate capacity grants and FIFO queue processing.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->