### PR TITLE
fix(deps): override html-to-text to 10.0.1 to clear CVE-2026-40345

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9723,12 +9723,22 @@
       "license": "MIT"
     },
     "node_modules/deepmerge-ts": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
-      "integrity": "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-8.0.2.tgz",
+      "integrity": "sha512-uqbvqLUMrc6p0MO+WBRtTxY55hmyh94WRwI5a++PZe54X+bfVh59FSN7uWCBCW1CCVjzjnrwzfI8zidE2obMMw==",
+      "funding": [
+        {
+          "type": "ko-fi",
+          "url": "https://ko-fi.com/rebeccastevens"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/deepmerge-ts"
+        }
+      ],
       "license": "BSD-3-Clause",
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=16.9.0"
       }
     },
     "node_modules/define-data-property": {
@@ -11334,13 +11344,13 @@
       "license": "ISC"
     },
     "node_modules/html-to-text": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-10.0.0.tgz",
-      "integrity": "sha512-2OH59Gtprdczel+7Rxgpz9hGVJREaf8Lt1H4kZwWHpEn70VQKRuMNGsb2eDbwaTzrYzb0hheiOG1P7Dim0B4dQ==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-10.0.1.tgz",
+      "integrity": "sha512-GiVhRI1BatGARSCmlXWNCjDT0cWrwBWoeduLoV0WSKAgaV/wa+hUWy5LiQLUs4UwiUrE52ZCMfBGiKD87TDPrg==",
       "license": "MIT",
       "dependencies": {
         "@selderee/plugin-htmlparser2": "~0.12.0",
-        "deepmerge-ts": "^7.1.5",
+        "deepmerge-ts": "^8.0.1",
         "dom-serializer": "^2.0.0",
         "htmlparser2": "^10.1.0",
         "selderee": "~0.12.0"

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "vitest": "^4.1.9"
   },
   "overrides": {
+    "html-to-text": "10.0.1",
     "ws": "^8.21.0",
     "sharp": "^0.35.3",
     "postcss": "^8.5.18"


### PR DESCRIPTION
# What and why

The daily **Scheduled Image Vulnerability Scan** has failed since 2026-08-18: Trivy's `sca` job flags **CVE-2026-40345** (HIGH) in `deepmerge-ts` 7.1.5, fixed in 8.0.0. The dependency chain is `mailparser` -> `html-to-text` (exact pin `10.0.0`) -> `deepmerge-ts ^7.1.5`, so the upstream fix (html-to-text 10.0.1, a patch release bumping to `deepmerge-ts ^8.0.1`) never resolves on its own.

This PR adds one npm override, `"html-to-text": "10.0.1"`, lifting `deepmerge-ts` to 8.0.2. No new dependency; the only consumer is mailparser's `simpleParser` in the invoice-inbox extension.

**Migrations:** none.
**Test coverage:** existing invoice-inbox suite (19 files, 232 tests) passes against the new tree; lint 0 errors; `check:guards` clean.

## Checklist

- [x] Title follows Conventional Commits
- [x] `npm run lint` passes locally; invoice-inbox vitest suite green
- [x] No new or changed logic (dependency version override only)
- [x] No UI strings changed
- [x] No migrations
- [x] Core builds unaffected (no code changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned the `html-to-text` package to version 10.0.1 for more consistent application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->