### PR TITLE
fix(skatteverket): skattekonto sync no longer fails on rows without belopp fields

### DIFF
--- a/extensions/general/skatteverket/__tests__/skattekonto-client.test.ts
+++ b/extensions/general/skatteverket/__tests__/skattekonto-client.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Tests for the skattekonto API client's wire-shape normalization.
+ *
+ * Skatteverket's JSON schema for /transaktioner does NOT require the belopp
+ * fields: rows with no SKV-side amount (e.g. amount at Kronofogden) omit
+ * beloppSkatteverket entirely. Before normalization, such a row flowed as
+ * undefined into the NOT NULL belopp_skatteverket column and made the whole
+ * sync upsert fail for the company, permanently (issue #1821). The client
+ * must therefore guarantee numbers on every row it returns.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const skvRequestWithAuthMock = vi.fn()
+vi.mock('../lib/api-client', () => ({
+  skvRequestWithAuth: (...args: unknown[]) => skvRequestWithAuthMock(...args),
+}))
+
+import { getTransaktioner, SkatteverketSkattekontoError } from '../lib/skattekonto-client'
+import type { SkvAuth } from '../lib/api-client'
+
+const auth = { mode: 'system' } as SkvAuth
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+describe('getTransaktioner normalization', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('defaults a missing beloppSkatteverket to 0 and missing beloppKronofogden to null', async () => {
+    skvRequestWithAuthMock.mockResolvedValue(
+      jsonResponse({
+        tidigareTransaktioner: [
+          {
+            transaktionsidentitet: 42,
+            transaktionsdatum: '2026-08-01',
+            ranteberakningsdatum: '2026-08-01',
+            transaktionstext: 'Överlämnad till Kronofogden',
+            beloppKronofogden: -5000,
+            // beloppSkatteverket intentionally absent (optional per SKV schema)
+          },
+        ],
+        kommandeTransaktioner: [
+          {
+            transaktionsdatum: '2026-09-12',
+            forfallodatum: '2026-09-12',
+            ranteberakningsdatum: null,
+            transaktionstext: 'Debiterad preliminärskatt',
+            // both belopp fields absent
+          },
+        ],
+      }),
+    )
+
+    const result = await getTransaktioner(auth, '165500000001')
+
+    expect(result.tidigareTransaktioner).toHaveLength(1)
+    expect(result.tidigareTransaktioner[0].beloppSkatteverket).toBe(0)
+    expect(result.tidigareTransaktioner[0].beloppKronofogden).toBe(-5000)
+
+    expect(result.kommandeTransaktioner).toHaveLength(1)
+    expect(result.kommandeTransaktioner[0].beloppSkatteverket).toBe(0)
+    expect(result.kommandeTransaktioner[0].beloppKronofogden).toBeNull()
+    expect(result.kommandeTransaktioner[0].transaktionsidentitet).toBeNull()
+  })
+
+  it('passes real amounts through unchanged, including 0 and negatives', async () => {
+    skvRequestWithAuthMock.mockResolvedValue(
+      jsonResponse({
+        tidigareTransaktioner: [
+          {
+            transaktionsidentitet: 1,
+            transaktionsdatum: '2026-07-13',
+            ranteberakningsdatum: '2026-07-13',
+            transaktionstext: 'Arbetsgivaravgift juni 2026',
+            beloppSkatteverket: -15710,
+            beloppKronofogden: 0,
+          },
+        ],
+        kommandeTransaktioner: [
+          {
+            transaktionsidentitet: 2,
+            transaktionsdatum: '2026-09-12',
+            forfallodatum: '2026-09-12',
+            ranteberakningsdatum: '2026-09-12',
+            transaktionstext: 'Moms aug 2026',
+            beloppSkatteverket: 12000,
+            beloppKronofogden: null,
+          },
+        ],
+      }),
+    )
+
+    const result = await getTransaktioner(auth, '165500000001')
+
+    expect(result.tidigareTransaktioner[0].beloppSkatteverket).toBe(-15710)
+    expect(result.tidigareTransaktioner[0].beloppKronofogden).toBe(0)
+    expect(result.kommandeTransaktioner[0].beloppSkatteverket).toBe(12000)
+    expect(result.kommandeTransaktioner[0].beloppKronofogden).toBeNull()
+    expect(result.kommandeTransaktioner[0].transaktionsidentitet).toBe(2)
+  })
+
+  it('coerces a null beloppSkatteverket to 0 as well', async () => {
+    skvRequestWithAuthMock.mockResolvedValue(
+      jsonResponse({
+        tidigareTransaktioner: [
+          {
+            transaktionsidentitet: 7,
+            transaktionsdatum: '2026-08-02',
+            ranteberakningsdatum: '2026-08-02',
+            transaktionstext: 'Utmätning Kronofogden',
+            beloppSkatteverket: null,
+            beloppKronofogden: null,
+          },
+        ],
+      }),
+    )
+
+    const result = await getTransaktioner(auth, '165500000001')
+
+    expect(result.tidigareTransaktioner[0].beloppSkatteverket).toBe(0)
+    expect(result.tidigareTransaktioner[0].beloppKronofogden).toBeNull()
+    expect(result.kommandeTransaktioner).toEqual([])
+  })
+
+  it('defaults missing arrays to empty lists', async () => {
+    skvRequestWithAuthMock.mockResolvedValue(jsonResponse({}))
+
+    const result = await getTransaktioner(auth, '165500000001')
+
+    expect(result.tidigareTransaktioner).toEqual([])
+    expect(result.kommandeTransaktioner).toEqual([])
+  })
+
+  it('still maps felkod errors to Swedish messages', async () => {
+    skvRequestWithAuthMock.mockImplementation(() =>
+      Promise.resolve(jsonResponse({ felkod: 3, felmeddelande: 'whatever' }, 404)),
+    )
+
+    const err = await getTransaktioner(auth, '165500000001').then(
+      () => null,
+      e => e as Error,
+    )
+    expect(err).toBeInstanceOf(SkatteverketSkattekontoError)
+    expect(err?.message).toBe('Inget skattekonto är registrerat hos Skatteverket.')
+  })
+})

--- a/extensions/general/skatteverket/lib/skattekonto-client.ts
+++ b/extensions/general/skatteverket/lib/skattekonto-client.ts
@@ -1,7 +1,9 @@
 import { skvRequestWithAuth, type SkvAuth } from './api-client'
 import type {
+  SkatteverketBookedTransaction,
   SkatteverketSaldoResponse,
   SkatteverketTransaktionerResponse,
+  SkatteverketUpcomingTransaction,
   SkatteverketFel,
 } from '../types'
 
@@ -120,6 +122,60 @@ export async function getSaldo(
 }
 
 /**
+ * Wire shape of one transaction row in the /transaktioner response.
+ *
+ * Skatteverket's JSON schema only REQUIRES transaktionsidentitet (tidigare
+ * rows), transaktionsdatum, ranteberakningsdatum and transaktionstext. Both
+ * belopp fields are optional and are simply omitted when a row carries no
+ * amount on that side; observed in prod (issue #1821) where such a row made
+ * every sync for the company fail on the NOT NULL belopp_skatteverket
+ * column. The domain types promise numbers, so the gap is closed here at
+ * the API boundary: nothing downstream may ever see undefined.
+ */
+interface RawSkattekontoTransaktion {
+  transaktionsidentitet?: number | null
+  transaktionsdatum: string
+  forfallodatum?: string
+  ranteberakningsdatum?: string | null
+  transaktionstext: string
+  beloppSkatteverket?: number | null
+  beloppKronofogden?: number | null
+}
+
+function toAmount(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null
+}
+
+function normalizeBooked(tx: RawSkattekontoTransaktion): SkatteverketBookedTransaction {
+  return {
+    // Required by SKV's schema on tidigare rows; the cast documents that a
+    // violation is SKV breaking its own contract, not a case we invent
+    // identities for.
+    transaktionsidentitet: tx.transaktionsidentitet as number,
+    transaktionsdatum: tx.transaktionsdatum,
+    ranteberakningsdatum: tx.ranteberakningsdatum ?? null,
+    transaktionstext: tx.transaktionstext,
+    // No SKV-side amount means the row did not move money on the
+    // Skatteverket side (the amount, if any, lives at Kronofogden): 0 is
+    // the truthful value and satisfies the NOT NULL column.
+    beloppSkatteverket: toAmount(tx.beloppSkatteverket) ?? 0,
+    beloppKronofogden: toAmount(tx.beloppKronofogden),
+  }
+}
+
+function normalizeUpcoming(tx: RawSkattekontoTransaktion): SkatteverketUpcomingTransaction {
+  return {
+    transaktionsidentitet: tx.transaktionsidentitet ?? null,
+    transaktionsdatum: tx.transaktionsdatum,
+    forfallodatum: tx.forfallodatum as string,
+    ranteberakningsdatum: tx.ranteberakningsdatum ?? null,
+    transaktionstext: tx.transaktionstext,
+    beloppSkatteverket: toAmount(tx.beloppSkatteverket) ?? 0,
+    beloppKronofogden: toAmount(tx.beloppKronofogden),
+  }
+}
+
+/**
  * GET /skattekonton/{omfragad}/transaktioner
  *
  * @param omfragad   10/12-digit org/personnummer
@@ -144,9 +200,12 @@ export async function getTransaktioner(
     await handleErrorResponse(response)
   }
 
-  const data = (await response.json()) as Partial<SkatteverketTransaktionerResponse>
+  const data = (await response.json()) as {
+    tidigareTransaktioner?: RawSkattekontoTransaktion[]
+    kommandeTransaktioner?: RawSkattekontoTransaktion[]
+  }
   return {
-    tidigareTransaktioner: data.tidigareTransaktioner ?? [],
-    kommandeTransaktioner: data.kommandeTransaktioner ?? [],
+    tidigareTransaktioner: (data.tidigareTransaktioner ?? []).map(normalizeBooked),
+    kommandeTransaktioner: (data.kommandeTransaktioner ?? []).map(normalizeUpcoming),
   }
 }

--- a/extensions/general/skatteverket/types.ts
+++ b/extensions/general/skatteverket/types.ts
@@ -282,9 +282,14 @@ export interface SkatteverketBookedTransaction {
   ranteberakningsdatum: string | null
   /** Description (e.g. "Inbetalning bokförd 190412") */
   transaktionstext: string
-  /** Amount at Skatteverket (positive = credit, negative = debit) */
+  /**
+   * Amount at Skatteverket (positive = credit, negative = debit).
+   * Optional on the wire (SKV omits it for rows with no SKV-side amount,
+   * e.g. rows whose amount lives at Kronofogden); normalized to 0 in
+   * skattekonto-client.ts, so it is always a number here.
+   */
   beloppSkatteverket: number
-  /** Amount moved to Kronofogden (rare) */
+  /** Amount moved to Kronofogden (rare); normalized to null when absent */
   beloppKronofogden: number | null
 }
 
@@ -298,9 +303,9 @@ export interface SkatteverketUpcomingTransaction {
   ranteberakningsdatum: string | null
   /** Description */
   transaktionstext: string
-  /** Amount at Skatteverket */
+  /** Amount at Skatteverket; optional on the wire, normalized to 0 when absent */
   beloppSkatteverket: number
-  /** Amount at Kronofogden */
+  /** Amount at Kronofogden; normalized to null when absent */
   beloppKronofogden: number | null
   /** Often null on kommande: fall back to dedup_key */
   transaktionsidentitet: number | null


### PR DESCRIPTION
## Root cause

The support report behind #1821 ("Jag kan logga in pa skattekontot men synken gar inte igenom") is company 7fe716c6 (Aktiebolaget Roslagens Webbyra). Prod evidence:

- Vercel runtime errors on POST /api/extensions/ext/skatteverket/skattekonto/sync: `null value in column "belopp_skatteverket" of relation "skattekonto_transactions" violates not-null constraint`, for exactly this company at 2026-08-21 09:57 (first connect) and 2026-08-23 23:16-23:17 (the night of the support mail), plus company 058af3a3 (2XA Products AB) on 08-20. First occurrence 2026-07-25, so this is NOT a regression from #1610 or #1673.
- The company has an active token, connect works, and AGI/declaration calls with the same token return 200 (skatteverket_api_audit_log). Only the skattekonto sync fails.
- The company has zero rows in skattekonto_transactions and no skattekonto_last_synced_at: the upsert is one batch, so one poison row makes the entire sync fail, every time, because the row is always inside SKV's 555-day response window.

Why the null: Skatteverket's own JSON schema for /transaktioner (skattekonto v2.1.0, dev_docs) does not list beloppSkatteverket or beloppKronofogden as required. Rows whose amount lives at Kronofogden omit the SKV-side amount entirely. Our TypeScript types declared beloppSkatteverket as always present, the row builder passed undefined through, supabase-js sends missing keys as column default, and the NOT NULL column rejected the batch.

## Fix

Normalize at the API boundary in `getTransaktioner` (extensions/general/skatteverket/lib/skattekonto-client.ts):

- missing or null beloppSkatteverket becomes 0 (the row moved no money on the SKV side; the truthful value and satisfies NOT NULL)
- missing beloppKronofogden becomes null
- kommande transaktionsidentitet coerced to null when absent (matches the existing type)

Every consumer (dedup keys, sync upsert, takeover pairing, AGI settlement, events) flows from this one function, so the number contract now actually holds. Type docs updated to state the guarantee. No migration, no UI strings, no repair needed (no partial rows were ever written; the next sync after deploy imports everything).

Note: a row normalized to 0 kr on the SKV side cannot be booked as a verifikat (the engine requires both sides > 0), which is correct; it is display/KFM information.

## Tests

- New `extensions/general/skatteverket/__tests__/skattekonto-client.test.ts`: missing beloppSkatteverket defaults to 0 (tidigare + kommande), null coerced to 0, real amounts including 0 and negatives pass through, missing arrays default to empty, felkod mapping still yields Swedish messages.
- `npx vitest run extensions/general/skatteverket`: 39 files, 375 tests, all pass.
- `npm run lint`: 0 errors (pre-existing warnings only, none in touched files).

Fixes #1821

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SyDuePXxUFowaPBKpAv8SF