### PR TITLE
fix(build): payment-file route returns a Uint8Array body, not a Buffer

### DIFF
--- a/app/api/skatteverket/tax-payments/[period]/payment-file/route.ts
+++ b/app/api/skatteverket/tax-payments/[period]/payment-file/route.ts
@@ -218,7 +218,9 @@ export const GET = withRouteContext<{ params: Promise<{ period: string }> }>(
     .eq('id', agi.id)
     .eq('company_id', companyId)
 
-  return new Response(fileContent, {
+  // Buffer is not assignable to BodyInit under the strict build tsconfig
+  // (Buffer<ArrayBufferLike>); the repo convention is a Uint8Array view.
+  return new Response(new Uint8Array(fileContent), {
     headers: {
       'Content-Type': contentType,
       'Content-Disposition': `attachment; filename="${filename}"`,


### PR DESCRIPTION
Since #1845 merged, every PR's **Core Build (zero extensions)** job fails with:

```
app/api/skatteverket/tax-payments/[period]/payment-file/route.ts(221,23): error TS2345:
Argument of type 'Buffer<ArrayBufferLike>' is not assignable to parameter of type 'BodyInit | null | undefined'.
```

Main's push CI doesn't run that job, so it only shows on PRs (first seen on #1849, whose diff doesn't touch this file). One-line fix using the repo's existing convention for binary bodies (`new Response(new Uint8Array(buffer), …)`, as in the PDF/XLSX report routes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ScVhg6XsDtNXkiEQNV7LaZ