### PR TITLE
fix(ui): make ContextPicker dropdown clickable inside modal dialogs

### DIFF
--- a/components/common/ContextPicker.tsx
+++ b/components/common/ContextPicker.tsx
@@ -114,7 +114,12 @@ export function ContextPicker({
           <div
             ref={listRef}
             role="listbox"
-            className="fixed z-[60] min-w-[220px] max-w-[320px] rounded-lg border border-border bg-popover py-1 shadow-lg animate-in fade-in slide-in-from-top-1 duration-150"
+            // Portaled to document.body, so inside a modal dialog the list is
+            // DOM-wise outside DialogContent: data-dialog-companion keeps a
+            // click in it from dismissing the dialog, and pointer-events-auto
+            // undoes the modal body lock that would swallow item clicks.
+            data-dialog-companion=""
+            className="pointer-events-auto fixed z-[60] min-w-[220px] max-w-[320px] rounded-lg border border-border bg-popover py-1 shadow-lg animate-in fade-in slide-in-from-top-1 duration-150"
             style={{ top: pos.top, left: pos.left }}
           >
             <div className="max-h-72 overflow-y-auto px-1">


### PR DESCRIPTION
# What and why

A user could not switch ROT to RUT in the Begar utbetalning for ROT/RUT dialog (follow-up to #1884 / PR #1891): the type and year pickers opened but clicks on items did nothing, so a paid RUT invoice stayed unreachable.

Root cause: ContextPicker portals its listbox to document.body. Inside a modal Radix dialog the body carries pointer-events: none (modal lock), the portaled list inherits it, item clicks never register, and the picker's own outside-click handler then closes the menu, so selection silently fails. Page-toolbar pickers are unaffected (no body lock without a modal).

Fix: apply the sanctioned companion-overlay pattern already used by AccountCombobox and HelpPopover to ContextPicker's listbox: `pointer-events-auto` undoes the modal body lock, `data-dialog-companion` keeps DialogContent/SheetContent from dismissing the dialog on a click in the list. Both are no-ops outside dialogs. This also fixes the year picker in the same dialog.

## Checklist

- [x] Title follows Conventional Commits
- [x] `npm run lint` and `npm run check:guards` pass locally
- [ ] New or changed logic in `lib/` or `app/api/` has tests (n/a: component-only change; component UI is outside the repo's test scope)
- [ ] New or changed UI strings in both message files (n/a: no strings changed)
- [x] No migrations
- [x] Core builds with zero extensions (no extension imports touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
