### PR TITLE
docs(connector): name the Claude.ai auth mode and OAuth client to pick

### DIFF
--- a/claude-plugin/CONNECTORS.md
+++ b/claude-plugin/CONNECTORS.md
@@ -8,7 +8,8 @@ This plugin bundles exactly one connector: the Accounted MCP server, the same se
 
 ## How the connection works
 
-- **Lazy authentication.** The server answers `initialize`, `tools/list` and the documentation tools (`accounted_search_tools`, `accounted_list_skills`, `accounted_load_skill`) without any credentials. The first company-scoped call returns an authentication challenge, which Claude Code surfaces as `/mcp` → authenticate.
+- **Lazy authentication.** The server answers `initialize`, `tools/list` and the documentation tools (`accounted_search_tools`, `accounted_list_skills`, `accounted_load_skill`) without any credentials. The first company-scoped call returns an authentication challenge, which Claude Code surfaces as `/mcp` → authenticate and Claude.ai as an inline Connect prompt.
+- **Adding it by hand in Claude.ai** (Settings → Connectors → Add custom connector): choose Authentication **"Required when the server asks"** (not the auto-detected "None") and OAuth client **"register one automatically" (DCR)**; the server does not advertise CIMD yet. No extra headers, Streamable HTTP.
 - **Account creation inside the sign-in.** A user who has no Accounted account creates one on the sign-in screen the challenge opens (BankID or e-mail + 2FA). No visit to the website first. `/accounted:setup` walks the whole flow, including creating the company from the conversation.
 - **Every write is staged.** Write tools create a pending operation with a preview; nothing is booked until the user approves, either in chat via `accounted_approve_pending_operation` or in the web app.
 - **Data stays in the user's tenant.** The connector only ever sees companies the signed-in user is a member of, enforced server-side per call.

--- a/packages/accounted-mcp/README.md
+++ b/packages/accounted-mcp/README.md
@@ -63,8 +63,18 @@ codex mcp add accounted --url \
 ```
 
 Claude.ai and Claude Desktop: Settings > Connectors > Add custom connector,
-paste the URL. The connector works before you connect (documentation tools);
-the first company-scoped call opens the Connect prompt.
+paste the URL, then in step 2 choose:
+
+- **Authentication: "Required when the server asks."** Claude auto-detects
+  "None" because the server answers the handshake without credentials; with
+  "None" the first company-scoped call shows an error instead of the sign-in.
+- **OAuth client: "No client ID, register one automatically" (DCR).** The
+  server does not advertise Anthropic's hosted client metadata (CIMD) yet.
+- No additional headers; transport stays Streamable HTTP.
+
+The connector works before you connect (documentation tools); the first
+company-scoped call opens the sign-in prompt, where a new user creates the
+account.
 
 ## Compatibility
 


### PR DESCRIPTION
Claude.ai's *Add custom connector* dialog (step 2) auto-detects Authentication "None" for our server because lazy auth answers the handshake without credentials. With "None" the first company-scoped call surfaces an error instead of the sign-in prompt. The two correct choices are **"Required when the server asks"** and OAuth client **"register one automatically" (DCR)**, since CIMD is not advertised yet. Documented in the bridge README and the plugin's CONNECTORS.md. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018wCdzRTatKiDByKB8hCNT6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Claude.ai and Claude Desktop setup guidance.
  * Clarified that sign-in prompts appear when authentication is required.
  * Documented automatic OAuth client registration and Streamable HTTP connection requirements.
  * Added guidance for manually configuring authentication when requested by the server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->