### PR TITLE
fix(mcp-oauth): api_keys.company_id nullable so companyless signups can mint their key

### DIFF
--- a/app/api/mcp-oauth/token/route.ts
+++ b/app/api/mcp-oauth/token/route.ts
@@ -167,6 +167,13 @@ async function handleAuthorizationCodeGrant(params: URLSearchParams) {
     })
 
   if (insertError) {
+    // This 500 was silent while api_keys.company_id was NOT NULL and every
+    // companyless signup died here (2026-08-26): always log the DB error.
+    console.error('[mcp-oauth/token] api key insert failed', {
+      code: insertError.code,
+      message: insertError.message,
+      companyless: companyId === null,
+    })
     return NextResponse.json(
       { error: 'server_error', error_description: 'Failed to create API key' },
       { status: 500 }
@@ -214,6 +221,7 @@ async function handleRefreshTokenGrant(params: URLSearchParams) {
   })
 
   if (error) {
+    console.error('[mcp-oauth/token] refresh rotation failed', { code: error.code, message: error.message })
     return NextResponse.json(
       { error: 'server_error', error_description: 'Failed to rotate refresh token' },
       { status: 500 }

--- a/supabase/migrations/20260826090000_api_keys_company_id_nullable.sql
+++ b/supabase/migrations/20260826090000_api_keys_company_id_nullable.sql
@@ -1,0 +1,16 @@
+-- Migration: api_keys.company_id becomes nullable
+--
+-- Agent-first onboarding (#1814): a key minted from the OAuth popup before
+-- the user's first company exists is stored unbound (company_id NULL) and
+-- bound lazily by validateApiKey once a company exists. The column was made
+-- NOT NULL by the dynamic loop in 20260330130000_multi_tenant_company_refactor
+-- (line ~250 sets NOT NULL for every table in its list, api_keys included),
+-- which nothing exercised until the companyless flow: the token endpoint's
+-- insert violated it and every fresh Claude.ai authorization died with a 500
+-- ("Authorization with Accounted failed", 2026-08-26).
+--
+-- Consumers already handle NULL: validateApiKey returns companyId
+-- string|null, the MCP dispatcher answers NO_COMPANY_YET for company-scoped
+-- tools on an unbound key, and /api/events fails closed.
+
+ALTER TABLE public.api_keys ALTER COLUMN company_id DROP NOT NULL;

--- a/tests/pg/api-keys-unbound.pg.test.ts
+++ b/tests/pg/api-keys-unbound.pg.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { randomUUID, createHash } from 'node:crypto'
+import { getPool } from './setup'
+import { insertAuthUser } from './fixtures'
+
+/**
+ * Unbound API keys (migration 20260826090000): a key minted from the OAuth
+ * popup before the user's first company exists carries company_id NULL.
+ * The NOT NULL from 20260330130000's dynamic loop made the token endpoint's
+ * insert fail with a plain 500 on every fresh Claude.ai authorization; a
+ * mocked client cannot see a column constraint, so this pins it on real
+ * Postgres.
+ */
+describe('api_keys unbound insert.pg', () => {
+  it('accepts a key with no company binding', async () => {
+    const userId = await insertAuthUser()
+    const keyHash = createHash('sha256').update(randomUUID()).digest('hex')
+    const inserted = await getPool().query<{ id: string; company_id: string | null }>(
+      `INSERT INTO public.api_keys (user_id, company_id, key_hash, key_prefix, name, scopes)
+       VALUES ($1, NULL, $2, 'gnubok_sk_test', 'MCP-klient (OAuth)', ARRAY['companies:read'])
+       RETURNING id, company_id`,
+      [userId, keyHash],
+    )
+    expect(inserted.rows[0]!.company_id).toBeNull()
+
+    // The lazy bind heals exactly the unbound row.
+    const companyRes = await getPool().query<{ id: string }>(
+      `SELECT public.create_company_for_user($1::uuid, 'Bind AB', 'aktiebolag', NULL) AS id`,
+      [userId],
+    )
+    await getPool().query(
+      `UPDATE public.api_keys SET company_id = $1 WHERE id = $2 AND company_id IS NULL`,
+      [companyRes.rows[0]!.id, inserted.rows[0]!.id],
+    )
+    const healed = await getPool().query<{ company_id: string | null }>(
+      `SELECT company_id FROM public.api_keys WHERE id = $1`,
+      [inserted.rows[0]!.id],
+    )
+    expect(healed.rows[0]!.company_id).toBe(companyRes.rows[0]!.id)
+  })
+})


### PR DESCRIPTION
Every fresh Claude.ai authorization (register → consent → code) ended in a silent `POST /api/mcp-oauth/token` 500 ("Authorization with Accounted failed", refs ofid_fbdee05141ff3ef1 / ofid_e20cba39997eb371). Root cause: `api_keys.company_id` is `NOT NULL` — set by the dynamic loop in `20260330130000_multi_tenant_company_refactor.sql` (line ~250) for every table in its list — and the companyless key insert from the popup-signup flow (#1814 PR 1) violates it. Unit tests mock the Supabase client and no pg test inserted an unbound key, so repo, CI and prod all agreed and the constraint was never hit until a real signup.

- Migration `20260826090000`: `ALTER TABLE public.api_keys ALTER COLUMN company_id DROP NOT NULL`. Consumers already handle NULL (`validateApiKey` returns `string | null`, MCP answers `NO_COMPANY_YET`, `/api/events` fails closed).
- The token endpoint now logs the insert / rotation failure before answering 500: this class of failure was invisible in the runtime logs.
- New pg-real test pins the unbound insert and the lazy bind against real Postgres.

Existing keys are untouched (widening only). After the prod migration applies, removing and re-adding the connector should complete authorization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018wCdzRTatKiDByKB8hCNT6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API keys can now be created without an associated company and linked later when the company becomes available.
* **Bug Fixes**
  * Improved error logging for API-key creation and refresh-token rotation failures, while preserving existing error responses.
* **Tests**
  * Added coverage for creating unbound API keys and subsequently associating them with a company.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->