### PR TITLE
perf(auth): skip the MFA factor lookup once the session is at AAL2

### DIFF
--- a/lib/supabase/__tests__/middleware.test.ts
+++ b/lib/supabase/__tests__/middleware.test.ts
@@ -15,6 +15,7 @@ const state = vi.hoisted(() => ({
   authError: null as unknown,
   aal: null as null | { currentLevel: string; nextLevel: string },
   factors: null as null | { totp: Array<{ id: string; status: string }> },
+  listFactors: vi.fn(async () => ({ data: state.factors })),
   company: {
     data: [{ company_id: 'company-1', locale: 'sv', used_fallback: false }],
     error: null as unknown,
@@ -45,7 +46,7 @@ vi.mock('@supabase/ssr', () => ({
       signOut: state.signOut,
       mfa: {
         getAuthenticatorAssuranceLevel: vi.fn(async () => ({ data: state.aal })),
-        listFactors: vi.fn(async () => ({ data: state.factors })),
+        listFactors: (...args: unknown[]) => state.listFactors(...args),
       },
     },
     rpc: vi.fn(async () => state.company),
@@ -117,6 +118,7 @@ describe('updateSession redirect destinations', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     logState.info.mockClear()
+    state.listFactors.mockClear()
     state.user = null
     state.sessionId = 'session-1'
     state.authError = null
@@ -544,6 +546,34 @@ describe('updateSession redirect destinations', () => {
       const response = await run('/select-company')
 
       expect(response.status).toBe(200)
+    })
+
+    it('still asks for the factor list at aal1/aal1 before bouncing', async () => {
+      const response = await run('/invoices/new')
+
+      expect(new URL(locationOf(response)!).pathname).toBe('/mfa/enroll')
+      expect(state.listFactors).toHaveBeenCalledTimes(1)
+    })
+
+    it('never calls listFactors once the session is at aal2 (a verified factor is implied)', async () => {
+      state.aal = { currentLevel: 'aal2', nextLevel: 'aal2' }
+      // Even a factor list that would read as "none" must not matter here:
+      // the call is skipped, not just its result ignored.
+      state.factors = { totp: [] }
+
+      const response = await run('/invoices/new')
+
+      expect(response.status).toBe(200)
+      expect(state.listFactors).not.toHaveBeenCalled()
+    })
+
+    it('does not spend an MFA lookup on RSC and prefetch requests at aal2 either', async () => {
+      state.aal = { currentLevel: 'aal2', nextLevel: 'aal2' }
+
+      await run('/invoices', { headers: { rsc: '1' } })
+      await run('/invoices', { headers: { 'next-router-prefetch': '1', rsc: '1' } })
+
+      expect(state.listFactors).not.toHaveBeenCalled()
     })
   })
 

--- a/lib/supabase/middleware.ts
+++ b/lib/supabase/middleware.ts
@@ -379,16 +379,28 @@ async function updateSessionInner(
     }
 
     // MFA required but user has no factor enrolled yet → force enrollment
-    // Skip for users with no companies (still setting up)
-    const { companyId: companyIdForMfa } = await resolveCompanyOnce()
-    if (companyIdForMfa) {
-      const { data: factors } = await timed(timing, 'mfaMs', () =>
-        supabase.auth.mfa.listFactors(),
-      )
-      const hasVerifiedFactor = factors?.totp?.some(f => f.status === 'verified')
+    // Skip for users with no companies (still setting up).
+    //
+    // Only worth asking when the session is NOT at AAL2: reaching AAL2
+    // requires having verified a challenge on a verified factor, so the
+    // factor list cannot be empty there. auth-js implements listFactors()
+    // as a getUser() network round trip, and running it here on every
+    // page, RSC and prefetch request for every MFA-verified user was the
+    // second Supabase Auth call per request (measured via mw-mfa, PR #1922).
+    // The narrow case this defers is a user who unenrols their last factor
+    // mid-session: the JWT keeps aal2 until the next token refresh, so the
+    // enrolment bounce lands on the refresh instead of the next click.
+    if (aal?.currentLevel !== 'aal2') {
+      const { companyId: companyIdForMfa } = await resolveCompanyOnce()
+      if (companyIdForMfa) {
+        const { data: factors } = await timed(timing, 'mfaMs', () =>
+          supabase.auth.mfa.listFactors(),
+        )
+        const hasVerifiedFactor = factors?.totp?.some(f => f.status === 'verified')
 
-      if (!hasVerifiedFactor) {
-        return bounceToAuth(request, '/mfa/enroll')
+        if (!hasVerifiedFactor) {
+          return bounceToAuth(request, '/mfa/enroll')
+        }
       }
     }
   }


### PR DESCRIPTION
Stacked on #1922 (it instruments the same block); base switches to `main` once that merges.

## Why

The proxy's enforced-MFA branch (`lib/supabase/middleware.ts`) called `supabase.auth.mfa.listFactors()` on **every** page, RSC and prefetch request for every MFA-verified user with a company. In auth-js 2.110 `listFactors()` is implemented as a `getUser()` network round trip, so hosted page requests were paying two sequential Supabase Auth calls (the `getUser()` at the top plus this one), ~20 to 60 ms each. This is the `mw-mfa` phase that #1922 makes visible.

## What

At AAL2 a verified factor exists by construction: the session can only reach AAL2 by verifying a challenge on a verified factor. So the factor lookup (and the company resolution that gates it) now runs only on the aal1/aal1 path, i.e. users who have not enrolled yet, where it behaves exactly as before. No change to who gets bounced to `/mfa/verify` or `/mfa/enroll` in any state the gate previously handled.

The one deferred case: a user who unenrols their **last** factor mid-session keeps `aal2` in the JWT until the next token refresh, so the forced-enrolment bounce lands on that refresh instead of the very next click. Before, it landed on the next request. Documented in the code.

Effect: minus one Supabase Auth round trip (~20 to 60 ms) on every hosted page/RSC/prefetch request for MFA-verified users. Verify after deploy: `proxy completed` logs, `mfaMs` p50 for `kind=page|rsc|prefetch` drops to ~0 (protocol in `scripts/perf/README.md`).

## Tests

`lib/supabase/__tests__/middleware.test.ts` (+3, 48 total): aal1/aal1 still calls `listFactors` once and bounces to `/mfa/enroll`; at aal2 `listFactors` is never called even when the factor list would read as empty (the call is skipped, not just its result ignored); no MFA lookup on RSC and prefetch requests at aal2. Existing step-up, enrolment and no-company cases unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
