### PR TITLE
fix(build): bound Turbopack build memory to stop Vercel OOM kills

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -128,6 +128,17 @@ const nextConfig: NextConfig = {
     // (lib/reference-data) is independent of this and refreshes on its own.
     // Default was 0 (always refetch). Static routes keep the 5 min default.
     staleTimes: { dynamic: 30, static: 300 },
+    // Vercel's standard build container OOM-kills the build since 2026-08-26
+    // (the tree outgrew it; SIGKILL during "Creating an optimized production
+    // build"). Two knobs, disjoint phases:
+    // - compile phase (Turbopack, where the kills happen): evict finished
+    //   tasks to the on-disk cache after every snapshot instead of the lazier
+    //   'auto' default. Trades some compile speed for a bounded working set;
+    //   requires the persistent FS cache, which is on by default in Next 16.
+    turbopackMemoryEviction: 'full',
+    // - static-generation phase: cap prerender workers (default is cores-1;
+    //   each is a full Node process on the shared container RAM).
+    cpus: 2,
   },
   // PostHog reverse proxy. Keeping analytics same-origin buys three things:
   // the strict CSP below needs NO posthog hosts (`connect-src 'self'` already


### PR DESCRIPTION
# What and why

Since the white-label merge (#1956) the production build outgrew Vercel's standard build container: 2 of the last 3 builds died with SIGKILL/OOM during "Creating an optimized production build" (dpl_DGueivex3Np4aH9kqTGARoJTNu7n, dpl_8uVGAf4nNcGpyp3dq68zdagTMDk8). Users are unaffected (failed builds keep the previous deployment live) but every merge is currently a coin flip.

Two knobs in `next.config.ts` `experimental`, governing disjoint build phases, both verified against the installed Next 16.3.1 config schema:

- `turbopackMemoryEviction: 'full'` — the compile-phase knob (where the kills happen): evicts finished Turbopack tasks to the persistent FS cache after every snapshot, bounding the working set. Trades some compile speed.
- `cpus: 2` — caps the static-generation worker pool (default is cores-1 full Node processes sharing the container RAM).

No migrations. Complementary (not a substitute): enabling Enhanced Build Machines in the Vercel project settings, which is Emil's dashboard toggle.

## Checklist

- [x] Title follows Conventional Commits
- [x] Config-only change, validated against next/dist/server/config-schema (CONFIG VALID); the PR's own Vercel preview build is the real test
- [x] No new UI strings, no migrations, no extension imports

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved build resource management by reclaiming Turbopack memory more aggressively.
  * Limited static generation to two CPUs for more predictable build performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->