### PR TITLE
docs(mcp): onboarding skill branches on the named previous system

### DIFF
--- a/extensions/general/mcp-server/skills/onboarding.ts
+++ b/extensions/general/mcp-server/skills/onboarding.ts
@@ -100,11 +100,22 @@ When the user had a previous system, history comes before the bank: it is
 the fastest path to a ledger that shows real value, and bank history rarely
 reaches far enough back anyway.
 
-1. Tell them where to export: **Fortnox** Register → Exportera → SIE 4,
-   **Visma eEkonomi** Bokföring → Export SIE, **Bokio** Inställningar →
-   Exportera data → SIE, **Björn Lundén / Briox / Wint** under Export.
-   Every Swedish system exports SIE4 (.se/.sie); ask them to attach the
-   file here in the chat.
+1. Branch on WHICH system they name:
+   - **Fortnox / Björn Lundén / Briox / Wint** (API-connected systems):
+     offer TWO paths and recommend by need. The FULL migration at
+     \`/import?mode=migration&provider=<fortnox|bjornlunden|briox|wint>\`
+     connects to the old system directly and fetches every fiscal year
+     PLUS invoices, customers, suppliers and documents: recommend it when
+     they have open fakturor or want underlag along. The QUICK path is a
+     SIE export dropped here (Fortnox: Register → Exportera → SIE 4):
+     ledger only, fastest. Either way the result lands in the same books.
+   - **Visma eEkonomi / Bokio**: no API export exists; ask for the SIE
+     file (Visma: Bokföring → Export SIE; Bokio: Inställningar →
+     Exportera data → SIE) and use the drop card. The wizard at
+     \`/import?mode=migration&provider=<visma|bokio>\` can complement with
+     invoices and customers AFTER the SIE import.
+   - **Annat/okänt system**: every Swedish system exports SIE4
+     (.se/.sie); ask them to export it and drop it here.
 2. As soon as SIE import is the next step, call
    \`gnubok_create_sie_upload\`. On claude.ai/Desktop it renders a
    DRAG-AND-DROP card: the user drops the file on it and the card itself


### PR DESCRIPTION
## What

From the founder's design note: "think of how the process should look if they say 'Yeah, I had Fortnox before'". The skill's SIE step now branches on the named system instead of one generic export instruction:

- **Fortnox / Björn Lundén / Briox / Wint** (API-connected): two offered paths — the **full migration wizard** (`/import?mode=migration&provider=…`, fetches all fiscal years + invoices + customers + documents; recommend when open fakturor/underlag matter) vs the **quick SIE drop** (ledger only, fastest).
- **Visma eEkonomi / Bokio** (no API export): SIE file first via the drop card; the wizard complements with invoices/customers afterwards.
- **Annat/okänt**: universal SIE4 export ask.

Skill text only; matches the provider capability matrix in `arcim-migration` (`sieViaApi`). A future `accounted_connect_migration` card-tool would give the wizard path the same one-click feel as bank/SKV — left as a follow-up.

Skills tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated onboarding guidance to provide accounting-system-specific migration options.
  * Added full migration and quick SIE-4 export paths for supported API-connected systems.
  * Added tailored instructions for Visma eEkonomi, Bokio, and unknown accounting systems.
  * Clarified when the migration wizard should be used as a complement to a SIE file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->