### PR TITLE
fix(mcp): widget-bearing tools must be read-only: Claude.ai drops write-annotated interactive tools

### DIFF
--- a/extensions/general/mcp-server/__tests__/strict-schemas.test.ts
+++ b/extensions/general/mcp-server/__tests__/strict-schemas.test.ts
@@ -41,4 +41,18 @@ describe('MCP tool inputSchema strictness', () => {
 
     expect(missing).toEqual([])
   })
+
+  it('every widget-bearing tool is read-only: Claude.ai drops write-annotated interactive tools', () => {
+    // A tool with definition-level _meta.ui renders on every call. Claude.ai
+    // accepts that only for read-only tools and silently DROPS a
+    // write-annotated one from the connector (E2E #9, 2026-08-26: the SIE
+    // drop card flapped into the Interactive list and vanished). Widget
+    // tools mint links/lists only; actual writes go through separate
+    // approval-gated tools the widget calls.
+    const writers = tools
+      .filter((t) => (t as { _meta?: { ui?: unknown } })._meta?.ui !== undefined)
+      .filter((t) => t.annotations.readOnlyHint !== true)
+      .map((t) => t.name)
+    expect(writers).toEqual([])
+  })
 })

--- a/extensions/general/mcp-server/server.ts
+++ b/extensions/general/mcp-server/server.ts
@@ -16387,7 +16387,15 @@ export const tools: McpTool[] = [
     },
     _meta: { ui: { resourceUri: 'ui://sie-drop/app.html' } },
     annotations: {
-      readOnlyHint: false,
+      // readOnlyHint MUST stay true on widget-bearing tools: Claude.ai
+      // accepts always-render widgets only on read-only tools and DROPS a
+      // write-annotated one from the connector entirely (the tool flapped
+      // into the Interactive list and vanished, E2E #9 2026-08-26; every
+      // surviving widget tool was readOnly). Honest too: this only mints a
+      // short-lived upload URL; the actual write is the staged
+      // gnubok_import_sie, same shape as receipt_matcher (read-only tool,
+      // writes via separate approval-gated tools).
+      readOnlyHint: true,
       destructiveHint: false,
       idempotentHint: false,
       openWorldHint: false,


### PR DESCRIPTION
## The bug that survived three fixes

The SIE drop card flapped into Claude.ai's Interactive-tools list and vanished — even after a full connector remove/re-add. Eliminated against live prod data: scope filtering (key has the full grant), a tool-count cap (tool sits at index 117/138 with visible neighbors at 118/119), stale cache (server answered 6/6 identical), schema shape (byte-identical structure to surviving tools). The one discriminator left: **every surviving interactive tool has `readOnlyHint: true`; the dropped one was the only widget-bearing write.** Claude.ai accepts always-render widgets only on read-only tools and silently drops the tool from the connector otherwise.

## Fix

- `gnubok_create_sie_upload` → `readOnlyHint: true`. Honest: it only mints a short-lived upload URL; the actual write is the staged `gnubok_import_sie` — the exact receipt_matcher shape (read-only widget tool, writes via separate approval-gated tools). Call-time scope enforcement (`bookkeeping:write`) is unchanged.
- New guard test: every tool with definition-level `_meta.ui` must be read-only, so no future widget tool repeats this.

Full mcp-server suite: 100 files / 1048 tests green; tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the widget tool’s permissions metadata to accurately identify it as read-only.
  - Improved safety by ensuring write actions remain restricted to the approval-gated import flow.

- **Tests**
  - Added regression coverage to verify that tools displaying UI metadata are not incorrectly marked as writable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->