### PR TITLE
fix(ui): cap DialogContent grid track so nowrap children cannot widen modals

### DIFF
--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -49,7 +49,11 @@ const DialogContent = React.forwardRef<
         }
       }}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-[var(--shadow-md)] max-h-[calc(100dvh-2rem)] overflow-y-auto scrollbar-visible data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-98 data-[state=open]:zoom-in-98 sm:rounded-xl",
+        // grid-cols-[minmax(0,1fr)]: the implicit auto track sizes to the widest
+        // child's min-content, and nowrap text (truncate) counts at full width
+        // there, so one long description widens every sibling past the dialog
+        // edge. minmax(0,1fr) caps the track at the content box.
+        "fixed left-[50%] top-[50%] z-50 grid grid-cols-[minmax(0,1fr)] w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-[var(--shadow-md)] max-h-[calc(100dvh-2rem)] overflow-y-auto scrollbar-visible data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-98 data-[state=open]:zoom-in-98 sm:rounded-xl",
         className
       )}
       {...props}


### PR DESCRIPTION
## What

One-line hardening in `components/ui/dialog.tsx`: DialogContent goes from an implicit auto grid column to `grid-cols-[minmax(0,1fr)]`.

## Why

DialogContent is `display: grid`, and its implicit auto track sizes to the widest child's min-content. Chrome counts nowrap text (`truncate`, `whitespace-nowrap`) at its full width in that calculation even though it truncates at layout time. One long description (reported: a candidate row in `MatchVerifikationPicker` inside "Matcha mot befintlig verifikation") widened the track past the dialog, stretched every sibling to the oversized track, and clipped the whole right column of the modal behind a horizontal scrollbar.

`minmax(0,1fr)` caps the track at the dialog's content box, so truncation engages as intended. This fixes the same failure class in every modal at once (~30 dialog components carry truncate/nowrap rows). PR #1732 fixed inner grids to `minmax(0,1fr)` but missed the primitive's own track. No caller passes `grid-cols-*` to DialogContent; a future override still wins via tailwind-merge.

## Migrations

No.

## Test coverage

No component/E2E test rig exists for layout. Verified with a headless-Chrome replica of the reported dialog DOM: `scrollWidth` 696 vs `clientWidth` 510 before the change, 510/510 after, with children returning from 648px to the correct 462px. Lint and `check:guards` clean (dialog-overflow-risk baseline unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented long, unwrapped content from expanding dialogs beyond their intended width.
  * Improved dialog layout behavior for oversized text and content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->