### PR TITLE
docs(plugin): starter prompt nudges the connector's onboarding guide

### DIFF
--- a/claude-plugin/CONNECTORS.md
+++ b/claude-plugin/CONNECTORS.md
@@ -16,7 +16,7 @@ https://claude.ai/customize/connectors?modal=add-custom-connector&connectorName=
 
 Pair the link with a starter prompt the user pastes as their first message. It stays copy-paste ready for everyone because it points the agent at what it already knows (Claude memory, earlier chats) instead of containing the user's own data; the server-side onboarding skill carries the rest of the flow:
 
-> Sätt upp mitt företag i Accounted. Utgå från det du redan vet om mig och mitt bolag (organisationsnummer, bank, tidigare bokföringssystem) och fråga bara efter det som saknas. Håll det kort.
+> Sätt upp mitt företag i Accounted och följ kopplingens onboarding-guide. Utgå från det du redan vet om mig och mitt bolag och fråga bara efter det som saknas. Håll det kort.
 
 ## How the connection works
 


### PR DESCRIPTION
One-line docs change: the published starter prompt becomes

> Sätt upp mitt företag i Accounted och följ kopplingens onboarding-guide. Utgå från det du redan vet om mig och mitt bolag och fråga bara efter det som saknas. Håll det kort.

Rationale: several E2E runs composed the first reply from tool descriptions before the onboarding skill loaded. The guide-nudge steers skill loading from message one; steps and error handling deliberately stay in the server-side skill (updatable), and personal data stays in Claude memory (keeps the prompt copy-paste-able for everyone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)