### PR TITLE
feat(onboarding): the hosted checklist closes with Connect to Claude

### DIFF
--- a/components/onboarding/NewUserChecklist.tsx
+++ b/components/onboarding/NewUserChecklist.tsx
@@ -18,6 +18,7 @@ import { ENABLED_EXTENSION_IDS } from '@/lib/extensions/_generated/enabled-exten
 import { useCapability } from '@/contexts/CompanyContext'
 import { CAPABILITY } from '@/lib/entitlements/keys'
 import type { InitialSetupPath, InitialSetupState } from '@/types'
+import { useBranding } from '@/lib/branding/brand-context'
 
 interface NewUserChecklistProps {
   initialState: InitialSetupState
@@ -78,6 +79,7 @@ export default function NewUserChecklist({
   sieSweep = null,
 }: NewUserChecklistProps) {
   const t = useTranslations('initial_setup')
+  const { appName } = useBranding()
   const router = useRouter()
   const showError = useErrorToast()
   const { formatDateLong } = useFormat()
@@ -217,9 +219,17 @@ export default function NewUserChecklist({
     captureSetup('onboarding_setup_step_started', { step: 'receipts' })
     router.push(hasAi ? '/e/general/invoice-inbox' : '/settings/billing')
   }
-  const goAssistant = () => {
-    captureSetup('onboarding_setup_step_started', { step: 'assistant' })
-    router.push(hasAi ? '/onboarding/agent' : '/settings/billing')
+  // Founder call 2026-08-27: the closing CTA is "Anslut till Claude", not the
+  // in-app assistant calibration (still reachable from the assistant page).
+  // A user who finishes the hosted onboarding lands in Claude with everything
+  // already connected, where the MCP onboarding skill opens with findings and
+  // the Att göra-list instead of setup. The connector URL is built from the
+  // page origin so self-hosted and white-label domains link to themselves.
+  const goClaude = () => {
+    captureSetup('onboarding_setup_step_started', { step: 'claude' })
+    const serverUrl = `${window.location.origin}/api/extensions/ext/mcp-server/mcp?tool_namespace=accounted`
+    const link = `https://claude.ai/customize/connectors?modal=add-custom-connector&connectorName=${encodeURIComponent(appName)}&connectorUrl=${encodeURIComponent(serverUrl)}`
+    window.open(link, '_blank', 'noopener')
   }
   const dismiss = () =>
     void persist({ dismissed: true }, 'dismiss').then((updated) => {
@@ -387,16 +397,15 @@ export default function NewUserChecklist({
           number={numbers.assistant}
           done={step5Done}
           active={activeStep === 5}
-          title={t('step_assistant_title')}
-          badge={t('step_assistant_beta')}
+          title={t('step_claude_title')}
           last
           action={(variant) => (
-            <Button size="sm" variant={variant} onClick={goAssistant}>
-              {t('step_assistant_action')}
+            <Button size="sm" variant={variant} onClick={goClaude}>
+              {t('step_claude_action')}
             </Button>
           )}
         >
-          {t('step_assistant_description')}
+          {t('step_claude_description')}
         </Step>
       </ol>
     </section>

--- a/messages/en.json
+++ b/messages/en.json
@@ -1518,7 +1518,10 @@
     "step_receipts_description": "Photo the receipt or forward the email to your inbox address, and the document is read and waiting for you.",
     "step_receipts_action": "Open the inbox",
     "step_receipts_channels": "Email · WhatsApp · upload",
-    "step_receipts_channels_no_wa": "Email · upload"
+    "step_receipts_channels_no_wa": "Email · upload",
+    "step_claude_title": "Connect to Claude",
+    "step_claude_description": "Do your bookkeeping from the chat: drop receipts and SIE files, reconcile the tax account and ask about your numbers. Everything is already connected.",
+    "step_claude_action": "Connect to Claude"
   },
   "tax_assessment_notices": {
     "title": "Final tax notices and remaining tax",

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -1518,7 +1518,10 @@
     "step_receipts_description": "Fota kvittot eller vidarebefordra mejlet till er inkorgsadress, så tolkas underlaget och väntar på dig.",
     "step_receipts_action": "Öppna inkorgen",
     "step_receipts_channels": "Mejl · WhatsApp · uppladdning",
-    "step_receipts_channels_no_wa": "Mejl · uppladdning"
+    "step_receipts_channels_no_wa": "Mejl · uppladdning",
+    "step_claude_title": "Anslut till Claude",
+    "step_claude_description": "Bokför via chatten: släpp kvitton och SIE-filer, stäm av skattekontot och ställ frågor om siffrorna. Allt är redan kopplat.",
+    "step_claude_action": "Anslut till Claude"
   },
   "tax_assessment_notices": {
     "title": "Slutskattebesked och kvarskatt",


### PR DESCRIPTION
## Founder call (2026-08-27)

The distribution split, after 13 E2E runs:
- **Brand-new businesses → Claude-first onboarding** (their first accounting system; no migration friction — the wedge at its purest).
- **Prior-system users → hosted onboarding** (the web migration wizard is the better tool for that job), and its **closing CTA becomes "Anslut till Claude"** — landing them in Claude with everything already connected, where the MCP skill (since #1967) opens with reconciliation findings + the Att göra-list instead of setup steps.

## Change

The final checklist step ("Bygg din bokföringsassistent") becomes **"Anslut till Claude"**: the button opens claude.ai's Add-custom-connector dialog prefilled (`connectorName` from the brand, `connectorUrl` built from `window.location.origin` so self-hosted and white-label domains link to their own server). The in-app assistant calibration remains reachable from the assistant page. sv + en strings added (hand-minimal JSON diff, no round-trip damage).

Small visual note for review: same Step/Button visuals, text + action swap only — worth a glance on the checklist before/after.

## Tests
- onboarding/i18n suites green; tsc clean; lint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Claude connection step to the initial setup checklist.
  * Added support for launching a branded Claude connector during onboarding.
  * Updated onboarding text and actions in English and Swedish.

* **Changes**
  * Removed the assistant beta badge and in-app assistant navigation from onboarding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->