### PR TITLE
fix(transactions): stop inbox row markers overlapping Belopp on mobile

### DIFF
--- a/components/transactions/TransactionInboxCard.tsx
+++ b/components/transactions/TransactionInboxCard.tsx
@@ -226,6 +226,11 @@ export default function TransactionInboxCard({
   const showOverflowMenu =
     showInvoiceMatchButton || showMatchVoucherItem || showAttachDocumentItem || showSplitItem || showEditItem || showMoveAccountItem || showIgnoreItem || showDeleteItem
 
+  // Pre-migration history row (ISO dates compare lexically): most likely
+  // corresponds to an already-imported verifikat, so it carries a quiet
+  // marker steering toward matching rather than re-booking.
+  const isPreMigration = !!preMigrationCutoff && transaction.date <= preMigrationCutoff
+
   // The foldout carries row detail only (actions live on the row: pill + ⋯).
   // Rows with nothing to show don't expand at all; classified imported rows
   // always have at least the payment-method line.
@@ -234,6 +239,7 @@ export default function TransactionInboxCard({
     (transaction.currency !== 'SEK' && transaction.amount_sek != null) ||
     Boolean(transaction.title_edited_at && originalName) ||
     Boolean(skvCounterpartDate) ||
+    isPreMigration ||
     (HAS_AI_EXTRACTION && (extraction.status === 'running' || extraction.status === 'failed'))
   const canExpand = hasFoldoutContent
   // An exiting row's foldout closes with it: the foldout <tr> has no exit
@@ -299,28 +305,35 @@ export default function TransactionInboxCard({
         <td className={cn(TD_CLASS, '!pl-0 whitespace-nowrap tabular-nums text-muted-foreground')}>
           {formatDate(transaction.date)}
         </td>
-        <td className={cn(TD_CLASS, 'max-w-0 w-full')}>
+        {/* overflow-hidden: the shrink-0 markers below don't truncate, so on
+            a viewport too narrow for them the cell must clip instead of
+            painting over the Belopp column. */}
+        <td className={cn(TD_CLASS, 'max-w-0 w-full overflow-hidden')}>
           <span className="row-collapsible flex min-w-0 items-center gap-2">
             <span className="truncate">{transaction.description}</span>
             <TransactionAttachmentIndicator documentId={attachedDocumentId} />
+            {/* The markers below are desktop-only (hidden md:*): on mobile
+                they overflowed the cell into Belopp; their info stays
+                reachable in the foldout (TransactionHistoryList gates its
+                markers the same way). */}
             {transaction.title_edited_at && (
               <span
-                className="shrink-0 text-xs text-muted-foreground"
+                className="hidden shrink-0 text-xs text-muted-foreground md:inline"
                 title={originalName ? t('original_name_tooltip', { name: originalName }) : undefined}
               >
                 {t('edited_badge')}
               </span>
             )}
             {skvCounterpartDate && (
-              <Badge variant="warning" className="h-4 shrink-0 gap-1 px-1.5 py-0 text-[10px]">
+              <Badge variant="warning" className="hidden h-4 shrink-0 gap-1 px-1.5 py-0 text-[10px] md:inline-flex">
                 <AlertCircle className="h-3 w-3" />
                 Möjlig 1930↔1630
               </Badge>
             )}
             {/* Quiet pre-migration marker (muted text, not a chip: it is
-                context, not an exception state). ISO dates compare lexically. */}
-            {preMigrationCutoff && transaction.date <= preMigrationCutoff && (
-              <span className="shrink-0 text-xs text-muted-foreground">
+                context, not an exception state). */}
+            {isPreMigration && (
+              <span className="hidden shrink-0 text-xs text-muted-foreground md:inline">
                 {t('pre_migration_marker')}
               </span>
             )}
@@ -485,7 +498,8 @@ export default function TransactionInboxCard({
                 {transaction.transaction_method ||
                 (transaction.currency !== 'SEK' && transaction.amount_sek != null) ||
                 transaction.title_edited_at ||
-                skvCounterpartDate ? (
+                skvCounterpartDate ||
+                isPreMigration ? (
                   <div className="space-y-1 py-1 text-xs text-muted-foreground">
                     {transaction.transaction_method && (
                       <p>
@@ -510,6 +524,7 @@ export default function TransactionInboxCard({
                         {t('skv_counterpart_body', { date: skvCounterpartDate })}
                       </p>
                     )}
+                    {isPreMigration && <p>{t('pre_migration_foldout')}</p>}
                   </div>
                 ) : null}
 

--- a/components/transactions/TransactionInboxCard.tsx
+++ b/components/transactions/TransactionInboxCard.tsx
@@ -237,7 +237,10 @@ export default function TransactionInboxCard({
   const hasFoldoutContent =
     Boolean(transaction.transaction_method) ||
     (transaction.currency !== 'SEK' && transaction.amount_sek != null) ||
-    Boolean(transaction.title_edited_at && originalName) ||
+    // No originalName requirement: below md the inline "redigerad" marker is
+    // hidden, so the foldout is the only place the edited state survives; it
+    // must open even when the original bank name is missing.
+    Boolean(transaction.title_edited_at) ||
     Boolean(skvCounterpartDate) ||
     isPreMigration ||
     (HAS_AI_EXTRACTION && (extraction.status === 'running' || extraction.status === 'failed'))
@@ -515,8 +518,12 @@ export default function TransactionInboxCard({
                         {formatCurrency(transaction.amount_sek)}
                       </p>
                     )}
-                    {transaction.title_edited_at && originalName && (
-                      <p>{t('original_name_tooltip', { name: originalName })}</p>
+                    {transaction.title_edited_at && (
+                      <p>
+                        {originalName
+                          ? t('original_name_tooltip', { name: originalName })
+                          : t('edited_no_original')}
+                      </p>
                     )}
                     {skvCounterpartDate && (
                       <p>

--- a/messages/en.json
+++ b/messages/en.json
@@ -3018,6 +3018,7 @@
     "delete_aria": "Delete transaction",
     "edit_title_aria": "Edit title",
     "edited_badge": "edited",
+    "edited_no_original": "The title has been edited from the bank's original name.",
     "pre_migration_marker": "from the period before your migration",
     "pre_migration_foldout": "This transaction is from the period before your migration: it most likely corresponds to an already imported voucher, so match it to an existing voucher rather than booking it again.",
     "original_name_tooltip": "Original bank name: {name}",

--- a/messages/en.json
+++ b/messages/en.json
@@ -3019,6 +3019,7 @@
     "edit_title_aria": "Edit title",
     "edited_badge": "edited",
     "pre_migration_marker": "from the period before your migration",
+    "pre_migration_foldout": "This transaction is from the period before your migration: it most likely corresponds to an already imported voucher, so match it to an existing voucher rather than booking it again.",
     "original_name_tooltip": "Original bank name: {name}",
     "edit_title_dialog_title": "Edit transaction title",
     "edit_title_warning": "Are you sure you want to edit the title of this transaction?",

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -3019,6 +3019,7 @@
     "edit_title_aria": "Ändra titel",
     "edited_badge": "redigerad",
     "pre_migration_marker": "från perioden före din migrering",
+    "pre_migration_foldout": "Transaktionen är från perioden före din migrering: den motsvarar troligen ett redan importerat verifikat, så matcha den hellre mot en befintlig verifikation än att bokföra på nytt.",
     "original_name_tooltip": "Bankens originalnamn: {name}",
     "edit_title_dialog_title": "Ändra transaktionens titel",
     "edit_title_warning": "Är du säker på att du vill ändra titeln på den här transaktionen?",

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -3018,6 +3018,7 @@
     "delete_aria": "Ta bort transaktion",
     "edit_title_aria": "Ändra titel",
     "edited_badge": "redigerad",
+    "edited_no_original": "Titeln har redigerats från bankens originalnamn.",
     "pre_migration_marker": "från perioden före din migrering",
     "pre_migration_foldout": "Transaktionen är från perioden före din migrering: den motsvarar troligen ett redan importerat verifikat, så matcha den hellre mot en befintlig verifikation än att bokföra på nytt.",
     "original_name_tooltip": "Bankens originalnamn: {name}",


### PR DESCRIPTION
# What and why

A user reported (mobile screenshot) that the Beskrivning text and Belopp run into each other on the transactions inbox on a phone.

**Root cause:** the inbox row's description cell is `max-w-0 w-full` with a truncating description span, but its inline markers, the "från perioden före din migrering" marker, the "redigerad" badge, and the "Möjlig 1930↔1630" badge, are `shrink-0` with no responsive gating. On a narrow viewport they overflow the cell and paint over the amount column. `TransactionHistoryList` already gates its equivalent markers with `hidden md:*`; the inbox card's markers were added without that guard.

**Fix** (`components/transactions/TransactionInboxCard.tsx`):
- Gate the three markers behind `hidden md:inline` / `hidden md:inline-flex`, matching the history list's pattern.
- Add `overflow-hidden` to the description cell as a backstop so any future `shrink-0` marker clips instead of overlapping Belopp.
- Surface the pre-migration context as a line in the row foldout (and count it in `hasFoldoutContent`) so the information stays reachable on mobile, where the inline marker is now hidden.

**Migrations:** none.

**Test coverage:** CSS/markup-only change in a component (component tests are out of test scope per project convention). `npm run lint`, `npm run check:types`, and `npm run check:guards` pass locally. New foldout string added to both `messages/sv.json` and `messages/en.json`.

## Checklist

- [x] Title follows Conventional Commits
- [x] `npm run lint` passes locally
- [ ] New or changed logic in `lib/` or `app/api/` has tests (n/a: component markup only)
- [x] New or changed UI strings exist in both `messages/sv.json` and `messages/en.json`
- [x] Migrations: none
- [x] Core builds with zero extensions enabled (no imports from `@/extensions/` in core code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YQkngviNKUTAwA5dhi2ff1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Transactions from before a migration are now clearly marked in the transaction inbox.
  - Additional details explain that these transactions may correspond to existing imported vouchers and should be matched rather than booked again.
  - Pre-migration transactions can only be expanded when relevant details are available.

- **Style**
  - Transaction status markers are displayed more cleanly on desktop and no longer overlap the amount column.
  - Improved layout behavior on smaller screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->