### PR TITLE
fix(kpi): reserve label headroom in monthly result bars so the endpoint value never clips

### DIFF
--- a/components/kpi/KPIStory.tsx
+++ b/components/kpi/KPIStory.tsx
@@ -76,10 +76,17 @@ function ResultBarsPane({ report }: { report: KPIReport }) {
 
   const W = 320
   const H = 120
-  const maxAbs = Math.max(...months.map((m) => Math.abs(m.net)), 1)
-  // Baseline sits lower when no month is negative, so positive bars get the room.
   const hasNegative = months.some((m) => m.net < 0)
-  const baseline = hasNegative ? H * 0.62 : H - 4
+  // Fixed headroom above (and below, when negatives exist) keeps the endpoint
+  // label inside the viewBox even when a single month dominates the scale.
+  const topPad = 16
+  const bottomPad = hasNegative ? 16 : 4
+  const maxPos = Math.max(...months.map((m) => Math.max(0, m.net)), 0)
+  const maxNeg = Math.max(...months.map((m) => Math.max(0, -m.net)), 0)
+  // One px-per-krona scale for both signs, so bar heights stay comparable.
+  const pxPerKr = (H - topPad - bottomPad) / Math.max(maxPos + maxNeg, 1)
+  // All-zero months keep the baseline at the bottom instead of the top.
+  const baseline = maxPos + maxNeg === 0 ? H - bottomPad : topPad + maxPos * pxPerKr
   const slot = W / months.length
   const barW = Math.min(30, slot * 0.62)
 
@@ -95,7 +102,7 @@ function ResultBarsPane({ report }: { report: KPIReport }) {
         })}
       >
         {months.map((m, i) => {
-          const scaled = (Math.abs(m.net) / maxAbs) * (hasNegative ? H * 0.55 : H - 26)
+          const scaled = Math.abs(m.net) * pxPerKr
           const h = m.net === 0 ? 2 : Math.max(3, scaled)
           const x = i * slot + (slot - barW) / 2
           const y = m.net >= 0 ? baseline - h : baseline


### PR DESCRIPTION
## What

The "Resultat per månad" pane on /kpis clipped the endpoint value label at the top edge of the chart whenever one month dominated and any month was negative (user report with screenshot: "492,2 tn" cut in half above the August bar). The same fixed-baseline math let a dominant negative month's bar and label overflow the bottom edge.

## Why it happened

With any negative month present, positive bars scaled to 55% of chart height against a baseline fixed at 62% height, leaving ~8px above the tallest bar; the label renders 5px above the bar top with a ~10.5px font, so its upper half landed outside the viewBox.

## Fix

Replace the fixed baseline in `ResultBarsPane` (`components/kpi/KPIStory.tsx`) with a single px-per-krona scale for both signs; the baseline is placed from the actual positive/negative maxima with 16px reserved on any side that can carry the label. Bar proportions stay honest (same scale for positive and negative), and the all-zero edge case keeps the baseline at the bottom.

## Migrations

No.

## Test coverage

Pure presentation component (outside the lib/ + app/api test scope). Verified geometrically against the reported case (dominant positive month with negatives present) plus dominant-negative and all-zero variants; `lint`, `check:types` (baseline), and `check:guards` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KtnsULW2jszA9uBnkMGnad

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved result-bar chart scaling for clearer comparisons between positive and negative values.
  * Ensured consistent spacing and sizing across chart bars.
  * Corrected baseline positioning, including charts with all-zero results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->