### PR TITLE
fix(arcim-migration): asset lives are a month short, and types are missed

### DIFF
--- a/components/extensions/general/ArcimMigrationWorkspace.tsx
+++ b/components/extensions/general/ArcimMigrationWorkspace.tsx
@@ -2072,6 +2072,9 @@ function formatSkipReasons(
     )
   }
   if (reasons.unsupported) parts.push(`${reasons.unsupported} kunde inte tolkas`)
+  if (reasons.typeUnresolved) {
+    parts.push(`${reasons.typeUnresolved} utan tillgångstyp: standardkonton användes`)
+  }
   if (reasons.noMatch) {
     const matchLabel = entityType === 'invoice' ? 'utan matchning' : 'utan matchning'
     parts.push(`${reasons.noMatch} ${matchLabel}`)

--- a/extensions/general/arcim-migration/lib/__tests__/import-assets.test.ts
+++ b/extensions/general/arcim-migration/lib/__tests__/import-assets.test.ts
@@ -492,3 +492,38 @@ describe('resolveAssetType', () => {
     expect(mapped.input.useful_life_months).toBe(60)
   })
 })
+
+/**
+ * Review of #2266 raised both of these: the label fallback picking silently
+ * among several candidates, and an unresolvable type still landing the asset
+ * on a category default with nothing said about it.
+ */
+describe('resolveAssetType refuses to guess', () => {
+  const base = { AccountAsset: 1010, AccountDepreciation: 1019, AccountValueLoss: 7811 }
+
+  it('returns nothing when two types share the number the label names', () => {
+    const types: FortnoxAssetType[] = [
+      { Id: 1, Number: '1300', Description: 'Utveckling', ...base },
+      { Id: 2, Number: '1300', Description: 'Programvara', ...base },
+    ]
+    expect(resolveAssetType({ Type: '1300' }, new Map(), types)).toBeUndefined()
+  })
+
+  it('returns nothing when two types share the description the label names', () => {
+    const types: FortnoxAssetType[] = [
+      { Id: 1, Number: '1220', Description: 'Inventarier', ...base },
+      { Id: 2, Number: '1230', Description: 'Inventarier', ...base },
+    ]
+    expect(resolveAssetType({ Type: 'Inventarier' }, new Map(), types)).toBeUndefined()
+  })
+
+  // The combined form identifies a type, so it still resolves even when the
+  // number alone would have been ambiguous.
+  it('still resolves on the combined form when only the number is shared', () => {
+    const types: FortnoxAssetType[] = [
+      { Id: 1, Number: '1300', Description: 'Utveckling', ...base },
+      { Id: 2, Number: '1300', Description: 'Programvara', ...base },
+    ]
+    expect(resolveAssetType({ Type: '1300 - Programvara' }, new Map(), types)?.Id).toBe(2)
+  })
+})

--- a/extensions/general/arcim-migration/lib/__tests__/import-assets.test.ts
+++ b/extensions/general/arcim-migration/lib/__tests__/import-assets.test.ts
@@ -3,6 +3,7 @@ import {
   categoryForAssetAccount,
   monthsBetween,
   mapFortnoxAsset,
+  resolveAssetType,
   isImportableStatus,
   importProviderAssets,
   fortnoxAssetMarker,
@@ -399,5 +400,95 @@ describe('importProviderAssets', () => {
       skipReasons: { failed: 1 },
       errorSample: 'insert failed',
     })
+  })
+})
+
+/**
+ * An asset acquired mid-month lost a month of its life: the plan running
+ * 2026-05-28 to 2031-04-30 is 60 months on the calendar, and the day-counting
+ * form made it 59. Every such asset then depreciated slightly too fast.
+ */
+describe('monthsBetween on the month grid', () => {
+  it('counts a mid-month plan as the whole 60 months', () => {
+    expect(monthsBetween('2026-05-01', '2031-04-30')).toBe(60)
+  })
+
+  // Fortnox does not document whether DepreciationFinal is the last day of the
+  // final month or the first day after it. Both have to give the same life.
+  it('reads both end-date conventions the same way', () => {
+    expect(monthsBetween('2026-05-01', '2031-04-30')).toBe(
+      monthsBetween('2026-05-01', '2031-05-01'),
+    )
+  })
+
+  it('keeps a whole-month plan unchanged', () => {
+    expect(monthsBetween('2024-03-01', '2027-03-01')).toBe(36)
+  })
+
+  it('never returns less than a month', () => {
+    expect(monthsBetween('2026-05-01', '2026-05-01')).toBe(1)
+  })
+})
+
+/**
+ * The account triple lives on the asset type. The list endpoint reports the
+ * type as a label and does not always carry TypeId, so an id-only lookup found
+ * nothing and the asset fell back to its category default: a register whose
+ * ledger sits on 1010 arriving on 1290.
+ */
+describe('resolveAssetType', () => {
+  const TYPES: FortnoxAssetType[] = [
+    {
+      Id: 7,
+      Number: '1300',
+      Description: 'Utveckling',
+      AccountAsset: 1010,
+      AccountDepreciation: 1019,
+      AccountValueLoss: 7811,
+    },
+  ]
+  const byId = new Map(TYPES.map((type) => [type.Id as number, type]))
+
+  it('finds the type by id when the payload carries one', () => {
+    expect(resolveAssetType({ TypeId: 7 }, byId, TYPES)).toBe(TYPES[0])
+  })
+
+  it('finds the type by its label when no id is given', () => {
+    expect(resolveAssetType({ Type: '1300 - Utveckling' }, byId, TYPES)).toBe(TYPES[0])
+  })
+
+  it('accepts the number or the description alone', () => {
+    expect(resolveAssetType({ Type: '1300' }, byId, TYPES)).toBe(TYPES[0])
+    expect(resolveAssetType({ Type: 'Utveckling' }, byId, TYPES)).toBe(TYPES[0])
+  })
+
+  it('ignores case and surrounding space', () => {
+    expect(resolveAssetType({ Type: '  utveckling ' }, byId, TYPES)).toBe(TYPES[0])
+  })
+
+  it('returns nothing when neither id nor label matches', () => {
+    expect(resolveAssetType({ Type: 'Något annat' }, byId, TYPES)).toBeUndefined()
+    expect(resolveAssetType({}, byId, TYPES)).toBeUndefined()
+  })
+
+  // The whole point: with the type found, the asset lands on the accounts its
+  // ledger uses instead of the category default.
+  it('puts the asset on the type accounts once the type is found', () => {
+    const mapped = mapFortnoxAsset(
+      {
+        Number: '6',
+        Description: 'Utvecklingsprojekt',
+        AcquisitionDate: '2026-05-28',
+        AcquisitionStart: '2026-05-01',
+        AcquisitionValue: 3_500_000,
+        DepreciationFinal: '2031-04-30',
+        Type: '1300 - Utveckling',
+      },
+      resolveAssetType({ Type: '1300 - Utveckling' }, byId, TYPES),
+    )
+    if (!('input' in mapped)) throw new Error('expected mapped input')
+    expect(mapped.input.bas_asset_account).toBe('1010')
+    expect(mapped.input.category).toBe('immaterial')
+    expect(mapped.input.useful_life_months).toBe(60)
   })
 })

--- a/extensions/general/arcim-migration/lib/__tests__/import-assets.test.ts
+++ b/extensions/general/arcim-migration/lib/__tests__/import-assets.test.ts
@@ -527,3 +527,50 @@ describe('resolveAssetType refuses to guess', () => {
     expect(resolveAssetType({ Type: '1300 - Programvara' }, new Map(), types)?.Id).toBe(2)
   })
 })
+
+/**
+ * From review of #2266: the separator's spacing varies between payloads, and
+ * which form a given Fortnox account carries is not something to depend on.
+ */
+describe('resolveAssetType ignores how the label is spaced', () => {
+  const TYPES: FortnoxAssetType[] = [
+    {
+      Id: 7,
+      Number: '1300',
+      Description: 'Utveckling',
+      AccountAsset: 1010,
+      AccountDepreciation: 1019,
+      AccountValueLoss: 7811,
+    },
+  ]
+
+  it.each([
+    '1300 - Utveckling',
+    '1300- Utveckling',
+    '1300 -Utveckling',
+    '1300-Utveckling',
+    '  1300  -  Utveckling  ',
+  ])('resolves %s', (label) => {
+    expect(resolveAssetType({ Type: label }, new Map(), TYPES)?.Id).toBe(7)
+  })
+
+  // The account triple has to survive the resolution, not just the match.
+  it('keeps the type accounts once resolved from an oddly spaced label', () => {
+    const mapped = mapFortnoxAsset(
+      {
+        Number: '6',
+        Description: 'Utvecklingsprojekt',
+        AcquisitionDate: '2026-05-28',
+        AcquisitionStart: '2026-05-01',
+        AcquisitionValue: 3_500_000,
+        DepreciationFinal: '2031-04-30',
+        Type: '1300-Utveckling',
+      },
+      resolveAssetType({ Type: '1300-Utveckling' }, new Map(), TYPES),
+    )
+    if (!('input' in mapped)) throw new Error('expected mapped input')
+    expect(mapped.input.bas_asset_account).toBe('1010')
+    expect(mapped.input.bas_accumulated_account).toBe('1019')
+    expect(mapped.input.bas_expense_account).toBe('7811')
+  })
+})

--- a/extensions/general/arcim-migration/lib/import-assets.ts
+++ b/extensions/general/arcim-migration/lib/import-assets.ts
@@ -21,6 +21,7 @@ import { createAsset } from '@/lib/bokslut/assets/asset-service'
 import { fetchAllRows } from '@/lib/supabase/fetch-all'
 import { roundOre } from '@/lib/money'
 import { isAccountNumber, isIsoDateShaped } from '@/lib/invariants'
+import { countCalendarMonths, dayAfter, firstOfMonth } from '@/lib/bookkeeping/accruals/compute'
 import { createLogger } from '@/lib/logger'
 import type { AssetCategory } from '@/types'
 import type { AssetSkipReasons } from '../types'
@@ -101,14 +102,19 @@ function isoDateOrNull(value: string | null | undefined): string | null {
 }
 
 /** Whole months between two ISO dates, rounded to nearest, minimum 1. */
+/**
+ * Useful life in whole months, from the month the plan starts through the
+ * month it ends.
+ *
+ * On the month grid rather than by counting days. The previous form added
+ * (toDay - fromDay) / 30, which turned a plan running 2026-05-28 to
+ * 2031-04-30 into 59 months instead of 60 and left every asset acquired
+ * mid-month a month short. Measuring to the day AFTER the final date also
+ * makes the answer the same whether the source reports the last day of the
+ * final month or the first day after it, which Fortnox does not document.
+ */
 export function monthsBetween(fromIso: string, toIso: string): number {
-  const from = new Date(`${fromIso}T00:00:00Z`)
-  const to = new Date(`${toIso}T00:00:00Z`)
-  const months =
-    (to.getUTCFullYear() - from.getUTCFullYear()) * 12 +
-    (to.getUTCMonth() - from.getUTCMonth()) +
-    (to.getUTCDate() - from.getUTCDate()) / 30
-  return Math.max(1, Math.round(months))
+  return Math.max(1, countCalendarMonths(firstOfMonth(fromIso), firstOfMonth(dayAfter(toIso))) - 1)
 }
 
 /** K2 standard useful life (schablon, 5 years) when the source gives no usable depreciation window. */
@@ -149,6 +155,42 @@ function accountString(value: number | string | null | undefined): string | null
   if (value === null || value === undefined) return null
   const text = String(value)
   return isAccountNumber(text) ? text : null
+}
+
+/**
+ * Find the asset's type, which is what carries the BAS account triple.
+ *
+ * By TypeId when the payload has one, and by the `Type` label when it does
+ * not. The list endpoint reports the type as text ("1300 - Utveckling") and
+ * does not always carry TypeId, so an id-only lookup silently found nothing
+ * and every asset fell back to its category default: assets whose ledger sits
+ * on 1010 arriving on 1290, and so on for any company whose types are not the
+ * standard ones.
+ */
+export function resolveAssetType(
+  asset: FortnoxAsset,
+  typeById: Map<number, FortnoxAssetType>,
+  types: readonly FortnoxAssetType[],
+): FortnoxAssetType | undefined {
+  if (typeof asset.TypeId === 'number') {
+    const byId = typeById.get(asset.TypeId)
+    if (byId) return byId
+  }
+  const label = asset.Type?.trim()
+  if (!label) return undefined
+
+  const normalize = (value: string) => value.trim().toLowerCase()
+  const target = normalize(label)
+  return types.find((type) => {
+    const number = type.Number?.trim() ?? ''
+    const description = type.Description?.trim() ?? ''
+    return (
+      (number !== '' && description !== '' &&
+        normalize(`${number} - ${description}`) === target) ||
+      (number !== '' && normalize(number) === target) ||
+      (description !== '' && normalize(description) === target)
+    )
+  })
 }
 
 /**
@@ -348,10 +390,7 @@ export async function importProviderAssets(
       continue
     }
 
-    const mapped = mapFortnoxAsset(
-      asset,
-      typeof asset.TypeId === 'number' ? typeById.get(asset.TypeId) : undefined,
-    )
+    const mapped = mapFortnoxAsset(asset, resolveAssetType(asset, typeById, types))
     if ('reason' in mapped) {
       skipReasons.unsupported = (skipReasons.unsupported ?? 0) + 1
       skipped++

--- a/extensions/general/arcim-migration/lib/import-assets.ts
+++ b/extensions/general/arcim-migration/lib/import-assets.ts
@@ -181,16 +181,36 @@ export function resolveAssetType(
 
   const normalize = (value: string) => value.trim().toLowerCase()
   const target = normalize(label)
-  return types.find((type) => {
-    const number = type.Number?.trim() ?? ''
-    const description = type.Description?.trim() ?? ''
-    return (
-      (number !== '' && description !== '' &&
-        normalize(`${number} - ${description}`) === target) ||
-      (number !== '' && normalize(number) === target) ||
-      (description !== '' && normalize(description) === target)
-    )
-  })
+
+  // Tried in order of how much the match proves. The combined form identifies
+  // a type; a number or a description on its own only narrows it, and two
+  // types can share either. Take a looser form only when it lands on exactly
+  // one type: picking the first of several would put the asset on another
+  // type's accounts, which is the failure this function exists to prevent,
+  // just harder to notice.
+  const candidates = [
+    (type: FortnoxAssetType) => {
+      const number = type.Number?.trim() ?? ''
+      const description = type.Description?.trim() ?? ''
+      return number !== '' && description !== '' &&
+        normalize(`${number} - ${description}`) === target
+    },
+    (type: FortnoxAssetType) => {
+      const number = type.Number?.trim() ?? ''
+      return number !== '' && normalize(number) === target
+    },
+    (type: FortnoxAssetType) => {
+      const description = type.Description?.trim() ?? ''
+      return description !== '' && normalize(description) === target
+    },
+  ]
+
+  for (const matches of candidates) {
+    const found = types.filter(matches)
+    if (found.length === 1) return found[0]
+    if (found.length > 1) return undefined
+  }
+  return undefined
 }
 
 /**
@@ -390,7 +410,15 @@ export async function importProviderAssets(
       continue
     }
 
-    const mapped = mapFortnoxAsset(asset, resolveAssetType(asset, typeById, types))
+    const assetType = resolveAssetType(asset, typeById, types)
+    if (!assetType) {
+      // Not fatal: the asset still imports on its category default. Counted
+      // because those accounts came from a guess about the category rather
+      // than from the source, so a register that does not tie to the ledger
+      // has a stated reason instead of looking like a deliberate choice.
+      skipReasons.typeUnresolved = (skipReasons.typeUnresolved ?? 0) + 1
+    }
+    const mapped = mapFortnoxAsset(asset, assetType)
     if ('reason' in mapped) {
       skipReasons.unsupported = (skipReasons.unsupported ?? 0) + 1
       skipped++

--- a/extensions/general/arcim-migration/lib/import-assets.ts
+++ b/extensions/general/arcim-migration/lib/import-assets.ts
@@ -179,7 +179,12 @@ export function resolveAssetType(
   const label = asset.Type?.trim()
   if (!label) return undefined
 
-  const normalize = (value: string) => value.trim().toLowerCase()
+  // All whitespace, not just the ends: "1300- Utveckling" and
+  // "1300 - Utveckling" name the same type, and which one a payload carries is
+  // not something to depend on. Two genuinely different types could collide
+  // under this, but the uniqueness check below turns that into no match rather
+  // than a wrong one.
+  const normalize = (value: string) => value.replace(/\s+/g, '').toLowerCase()
   const target = normalize(label)
 
   // Tried in order of how much the match proves. The combined form identifies
@@ -411,13 +416,6 @@ export async function importProviderAssets(
     }
 
     const assetType = resolveAssetType(asset, typeById, types)
-    if (!assetType) {
-      // Not fatal: the asset still imports on its category default. Counted
-      // because those accounts came from a guess about the category rather
-      // than from the source, so a register that does not tie to the ledger
-      // has a stated reason instead of looking like a deliberate choice.
-      skipReasons.typeUnresolved = (skipReasons.typeUnresolved ?? 0) + 1
-    }
     const mapped = mapFortnoxAsset(asset, assetType)
     if ('reason' in mapped) {
       skipReasons.unsupported = (skipReasons.unsupported ?? 0) + 1
@@ -441,6 +439,15 @@ export async function importProviderAssets(
     try {
       await createAsset(supabase, companyId, userId, mapped.input)
       imported++
+      if (!assetType) {
+        // Counted here rather than at resolution: an asset that turns out to
+        // be a duplicate or fails to import never reached the register, and
+        // saying its accounts came from a default would describe a row that
+        // does not exist. Not a skip either, the asset is in: the accounts
+        // came from a guess about the category rather than from the source,
+        // so a register that does not tie to the ledger has a stated reason.
+        skipReasons.typeUnresolved = (skipReasons.typeUnresolved ?? 0) + 1
+      }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       log.error('failed to import an asset', error as Error, {

--- a/extensions/general/arcim-migration/types.ts
+++ b/extensions/general/arcim-migration/types.ts
@@ -63,6 +63,13 @@ export interface SkipReasons {
  */
 export interface AssetSkipReasons extends SkipReasons {
   unsupported?: number
+  /**
+   * Assets imported on their category default accounts because the source
+   * type could not be resolved, or resolved ambiguously. Not a skip: the
+   * asset is in the register, but on accounts the source did not confirm, so
+   * the register may not tie to the ledger until someone looks.
+   */
+  typeUnresolved?: number
 }
 
 /**


### PR DESCRIPTION
Two faults in the Fortnox asset import from #1999, both reached by any company whose register does not use the standard asset types. Found while migrating a real company's register and reconciling it against the SIE-imported ledger.

## An asset acquired mid-month loses a month of its life

`monthsBetween` added `(toDay - fromDay) / 30` to a month difference. A plan running 2026-05-28 to 2031-04-30 measured **59** months rather than 60, so the asset depreciated slightly too fast for its whole life, and the register disagreed with the source system by one month's amount.

It now counts on the month grid, reusing `firstOfMonth`, `countCalendarMonths` and `dayAfter` from `lib/bookkeeping/accruals/compute` rather than adding a second set of date helpers. Measuring to the day *after* the final date also makes the result identical whether the source reports the last day of the final month (2031-04-30) or the first day after it (2031-05-01), which the Fortnox docs do not settle.

## The asset type is missed, so the accounts fall back to a default

The BAS account triple lives on the asset type, and the type was looked up by `TypeId` alone. The list endpoint reports the type as a label (`"1300 - Utveckling"`) and does not always carry `TypeId`, so the lookup silently found nothing and every asset fell back to its category default: a register whose ledger sits on 1010 arriving on 1290, with `category` derived from the wrong account in turn. Nothing in the result says it happened.

`resolveAssetType` now falls back to the label, matching `"number - description"`, the number alone, or the description alone, case and surrounding space insensitive.

## Tests

Ten. Four pin the month arithmetic, including that both end-date conventions give the same life and that a whole-month plan is unchanged at 36. Six cover the type lookup, the last showing the effect end to end: an asset landing on 1010 as `immaterial` with 60 months, instead of the category default with 59.

## Scope

Two files, no migrations, no new dependencies, no new helpers. `npm run lint`, `check:types`, `check:guards`, `vitest run` and `npm run build` all green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved asset type matching across IDs, numbers, descriptions, and combined labels, including case- and whitespace-insensitive matches.
  * Prevented ambiguous asset type matches from selecting an incorrect type.
  * Improved depreciation life calculations for mid-month, end-date, whole-month, and minimum one-month plans.
  * Assets with unresolved types now import using standard category accounts.

* **Improvements**
  * Skip reports now identify assets imported with standard accounts because their type could not be resolved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->