### PR TITLE
fix(arcim): leave a trace when mapping targets fall back to BAS only

### DIFF
--- a/extensions/general/arcim-migration/__tests__/mapping-targets.test.ts
+++ b/extensions/general/arcim-migration/__tests__/mapping-targets.test.ts
@@ -80,7 +80,10 @@ describe('buildMappingTargets', () => {
     const warn = vi.fn()
     await buildMappingTargets(supabaseWith(new Error('boom')), 'company-1', { warn })
     expect(warn).toHaveBeenCalledTimes(1)
-    expect(warn.mock.calls[0][1]).toMatchObject({ companyId: 'company-1' })
+    expect(warn.mock.calls[0][1]).toMatchObject({
+      companyId: 'company-1',
+      reason: 'boom',
+    })
   })
 
   it('does not warn on the ordinary path', async () => {

--- a/extensions/general/arcim-migration/__tests__/mapping-targets.test.ts
+++ b/extensions/general/arcim-migration/__tests__/mapping-targets.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import type { SupabaseClient } from '@supabase/supabase-js'
 
 import { buildMappingTargets } from '../lib/mapping-targets'
@@ -74,6 +74,21 @@ describe('buildMappingTargets', () => {
   })
 
   // An incomplete list still lets the migration run; an exception stops it.
+  // The fallback silently reproduces the problem this function fixes, so a
+  // mapping made against an incomplete list has to be explainable afterwards.
+  it('warns when it falls back, so an incomplete list leaves a trace', async () => {
+    const warn = vi.fn()
+    await buildMappingTargets(supabaseWith(new Error('boom')), 'company-1', { warn })
+    expect(warn).toHaveBeenCalledTimes(1)
+    expect(warn.mock.calls[0][1]).toMatchObject({ companyId: 'company-1' })
+  })
+
+  it('does not warn on the ordinary path', async () => {
+    const warn = vi.fn()
+    await buildMappingTargets(supabaseWith([]), 'company-1', { warn })
+    expect(warn).not.toHaveBeenCalled()
+  })
+
   it('falls back to BAS when the chart cannot be read', async () => {
     const targets = await buildMappingTargets(supabaseWith(new Error('boom')), 'company-1')
     expect(targets.length).toBeGreaterThan(1000)

--- a/extensions/general/arcim-migration/index.ts
+++ b/extensions/general/arcim-migration/index.ts
@@ -1028,7 +1028,7 @@ export const arcimMigrationExtension: Extension = {
           // express an account the company added outside the standard, so
           // such an account was impossible to map onto. See
           // ./lib/mapping-targets.
-          const mappingTargets = await buildMappingTargets(supabase, companyId)
+          const mappingTargets = await buildMappingTargets(supabase, companyId, moduleLog)
           const mappings = suggestMappings(allAccounts, mappingTargets, existingRecords)
           const mappingStats = getMappingStats(mappings)
 

--- a/extensions/general/arcim-migration/lib/mapping-targets.ts
+++ b/extensions/general/arcim-migration/lib/mapping-targets.ts
@@ -40,6 +40,7 @@ function classOf(accountNumber: string): number | undefined {
 export async function buildMappingTargets(
   supabase: SupabaseClient,
   companyId: string,
+  log?: { warn: (message: string, meta?: Record<string, unknown>) => void },
 ): Promise<MappingTarget[]> {
   let own: MappingTarget[] = []
   try {
@@ -57,8 +58,17 @@ export async function buildMappingTargets(
       account_class:
         typeof r.account_class === 'number' ? r.account_class : classOf(String(r.account_number)),
     }))
-  } catch {
+  } catch (error) {
+    // Degrading to BAS keeps the migration moving, but it silently reproduces
+    // the very problem this function exists to fix: the company's own accounts
+    // missing from the list. Leave a trace, so a mapping made against an
+    // incomplete list can be explained afterwards rather than looking like a
+    // deliberate choice.
     own = []
+    log?.warn('chart_of_accounts read failed; mapping targets fall back to BAS only', {
+      companyId,
+      reason: error instanceof Error ? error.message : 'unknown',
+    })
   }
 
   const seen = new Set(own.map((a) => a.account_number))


### PR DESCRIPTION
Follow-up to #2164, which added the company's own chart as mapping targets.

`buildMappingTargets` degrades to the BAS catalogue when the chart cannot be read. That is the right call, and I would not change it: an incomplete list still lets the migration proceed, while an exception stops it dead.

The problem is that the `catch` is empty. The fallback silently reproduces the exact condition #2164 exists to fix, the company's own accounts missing from the list, and afterwards nothing can distinguish a mapping made against the full list from one made against BAS alone. The user sees a dropdown that looks complete, maps onto it, and the migration proceeds.

It now warns with the company id and the reason. No behaviour change beyond that: the fallback still happens, the migration still proceeds, and the ordinary path is untouched.

Two tests: the warning on a failed read, and no warning on the ordinary path.

One file plus its caller and the test. `npm run lint`, `check:types`, `check:guards`, `vitest run` and `npm run build` all green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of chart-of-accounts loading failures during SIE data generation.
  - The system now records a warning with the affected company and error details before continuing with BAS-only mapping targets.

- **Tests**
  - Added coverage to verify warnings are emitted on failures and omitted during successful mapping-target construction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->