### PR TITLE
feat(reconciliation): sortable columns in the manual match view

### DIFF
--- a/components/reconciliation/ManualMatchMode.tsx
+++ b/components/reconciliation/ManualMatchMode.tsx
@@ -70,7 +70,9 @@ function SortTh({
   return (
     <th
       className={cn(TH_CLASS, className)}
-      aria-sort={active ? (sort.direction === 'asc' ? 'ascending' : 'descending') : 'none'}
+      // Only the active header carries aria-sort. "none" is the default, so
+      // stating it on every other column adds noise without adding meaning.
+      aria-sort={active ? (sort.direction === 'asc' ? 'ascending' : 'descending') : undefined}
     >
       <button
         type="button"

--- a/components/reconciliation/ManualMatchMode.tsx
+++ b/components/reconciliation/ManualMatchMode.tsx
@@ -1,6 +1,13 @@
 'use client'
 
 import { useCallback, useEffect, useMemo, useState } from 'react'
+import {
+  DEFAULT_RECON_SORT,
+  nextReconSort,
+  sortReconciliationItems,
+  type ReconSort,
+  type ReconSortColumn,
+} from '@/lib/reconciliation/item-sort'
 import { useTranslations } from 'next-intl'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
@@ -39,6 +46,49 @@ interface ManualMatchModeProps {
 
 const LIMIT = 200
 
+/**
+ * Sortable header for the two match tables. Deliberately local: the matching
+ * view is not on a shared list table (a selection in one table constrains the
+ * other), so it borrows the idiom rather than a component.
+ */
+function SortTh({
+  label,
+  column,
+  sort,
+  onSort,
+  className,
+  align,
+}: {
+  label: string
+  column: ReconSortColumn
+  sort: ReconSort
+  onSort: (column: ReconSortColumn) => void
+  className?: string
+  align?: 'right'
+}) {
+  const active = sort.column === column
+  return (
+    <th
+      className={cn(TH_CLASS, className)}
+      aria-sort={active ? (sort.direction === 'asc' ? 'ascending' : 'descending') : 'none'}
+    >
+      <button
+        type="button"
+        onClick={() => onSort(column)}
+        className={cn(
+          'inline-flex min-h-8 items-center gap-1 rounded-sm uppercase focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+          align === 'right' && 'ml-auto justify-end',
+        )}
+      >
+        {label}
+        <span aria-hidden="true" className={cn('text-[9px]', !active && 'text-muted-foreground/60')}>
+          {active ? (sort.direction === 'asc' ? '\u2191' : '\u2193') : '\u2195'}
+        </span>
+      </button>
+    </th>
+  )
+}
+
 export function ManualMatchMode({ account, window, onChanged }: ManualMatchModeProps) {
   const t = useTranslations('reconciliation')
   const { toast } = useToast()
@@ -49,6 +99,32 @@ export function ManualMatchMode({ account, window, onChanged }: ManualMatchModeP
   const [pickedEntries, setPickedEntries] = useState<Set<string>>(new Set())
   const [busy, setBusy] = useState(false)
   const [residualKind, setResidualKind] = useState<ResidualKind | ''>('')
+
+  // One sort per table, not one shared: the two sides hold different rows and
+  // the whole task is comparing them, so pinning both to the same order would
+  // work against the person doing the matching.
+  const [ledgerSort, setLedgerSort] = useState<ReconSort>(DEFAULT_RECON_SORT)
+  const [externalSort, setExternalSort] = useState<ReconSort>(DEFAULT_RECON_SORT)
+  const onLedgerSort = useCallback(
+    (column: ReconSortColumn) => setLedgerSort((s) => nextReconSort(s, column)),
+    [],
+  )
+  const onExternalSort = useCallback(
+    (column: ReconSortColumn) => setExternalSort((s) => nextReconSort(s, column)),
+    [],
+  )
+
+  // Sorted copies for rendering. Memoised so a re-render from selection state
+  // does not resort on every checkbox click. Selection is keyed by item_id, so
+  // reordering never disturbs what is picked.
+  const sortedLedger = useMemo(
+    () => (ledger ? sortReconciliationItems(ledger, ledgerSort) : null),
+    [ledger, ledgerSort],
+  )
+  const sortedExternal = useMemo(
+    () => (external ? sortReconciliationItems(external, externalSort) : null),
+    [external, externalSort],
+  )
 
   const base = `/api/reconciliation/accounts/${encodeURIComponent(account.account_key)}`
   const isSkv = account.kind === 'skattekonto'
@@ -219,13 +295,13 @@ export function ManualMatchMode({ account, window, onChanged }: ManualMatchModeP
               <thead>
                 <tr>
                   <th className={cn(TH_CLASS, 'w-8 px-2')} />
-                  <th className={cn(TH_CLASS, 'w-[96px]')}>{t('col_date')}</th>
-                  <th className={TH_CLASS}>{t('col_event')}</th>
-                  <th className={cn(TH_CLASS, 'w-[120px] text-right')}>{t('col_amount')}</th>
+                  <SortTh label={t('col_date')} column="date" sort={externalSort} onSort={onExternalSort} className="w-[96px]" />
+                  <SortTh label={t('col_event')} column="description" sort={externalSort} onSort={onExternalSort} />
+                  <SortTh label={t('col_amount')} column="amount" sort={externalSort} onSort={onExternalSort} className="w-[120px] text-right" align="right" />
                 </tr>
               </thead>
               <tbody className="stagger-enter">
-                {external.map((item) => {
+                {(sortedExternal ?? []).map((item) => {
                   const picked = pickedExternal.has(item.item_id)
                   return (
                     <tr
@@ -273,14 +349,14 @@ export function ManualMatchMode({ account, window, onChanged }: ManualMatchModeP
               <thead>
                 <tr>
                   <th className={cn(TH_CLASS, 'w-8 px-2')} />
-                  <th className={cn(TH_CLASS, 'w-[96px]')}>{t('col_date')}</th>
-                  <th className={cn(TH_CLASS, 'w-[90px]')}>{t('col_voucher')}</th>
-                  <th className={TH_CLASS}>{t('col_event')}</th>
-                  <th className={cn(TH_CLASS, 'w-[120px] text-right')}>{t('col_amount')}</th>
+                  <SortTh label={t('col_date')} column="date" sort={ledgerSort} onSort={onLedgerSort} className="w-[96px]" />
+                  <SortTh label={t('col_voucher')} column="voucher" sort={ledgerSort} onSort={onLedgerSort} className="w-[90px]" />
+                  <SortTh label={t('col_event')} column="description" sort={ledgerSort} onSort={onLedgerSort} />
+                  <SortTh label={t('col_amount')} column="amount" sort={ledgerSort} onSort={onLedgerSort} className="w-[120px] text-right" align="right" />
                 </tr>
               </thead>
               <tbody className="stagger-enter">
-                {ledger.map((item) => {
+                {(sortedLedger ?? []).map((item) => {
                   const picked = pickedEntries.has(item.item_id)
                   return (
                     <tr

--- a/lib/reconciliation/__tests__/item-sort.test.ts
+++ b/lib/reconciliation/__tests__/item-sort.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest'
+
+import type { ReconciliationItem } from '../schemas'
+import {
+  DEFAULT_RECON_SORT,
+  nextReconSort,
+  sortReconciliationItems,
+} from '../item-sort'
+
+function item(over: Partial<ReconciliationItem> & { item_id: string }): ReconciliationItem {
+  return {
+    item_type: 'journal_entry',
+    side: 'ledger',
+    bucket: 'unmatched_ledger',
+    date: '2026-09-01',
+    description: '',
+    amount: 0,
+    currency: 'SEK',
+    actions: [],
+    ...over,
+  } as ReconciliationItem
+}
+
+describe('sortReconciliationItems', () => {
+  it('does not mutate the input', () => {
+    const items = [item({ item_id: 'b', date: '2026-01-02' }), item({ item_id: 'a', date: '2026-01-01' })]
+    const before = items.map((i) => i.item_id)
+    sortReconciliationItems(items, { column: 'date', direction: 'asc' })
+    expect(items.map((i) => i.item_id)).toEqual(before)
+  })
+
+  it('sorts dates chronologically in both directions', () => {
+    const items = [
+      item({ item_id: 'mid', date: '2026-05-05' }),
+      item({ item_id: 'old', date: '2025-12-31' }),
+      item({ item_id: 'new', date: '2026-09-01' }),
+    ]
+    expect(
+      sortReconciliationItems(items, { column: 'date', direction: 'asc' }).map((i) => i.item_id),
+    ).toEqual(['old', 'mid', 'new'])
+    expect(
+      sortReconciliationItems(items, { column: 'date', direction: 'desc' }).map((i) => i.item_id),
+    ).toEqual(['new', 'mid', 'old'])
+  })
+
+  // Text sorting would put A10 before A9.
+  it('sorts vouchers by series then number, not as text', () => {
+    const items = [
+      item({ item_id: 'a10', voucher_series: 'A', voucher_number: 10 }),
+      item({ item_id: 'a9', voucher_series: 'A', voucher_number: 9 }),
+      item({ item_id: 'b1', voucher_series: 'B', voucher_number: 1 }),
+    ]
+    expect(
+      sortReconciliationItems(items, { column: 'voucher', direction: 'asc' }).map((i) => i.item_id),
+    ).toEqual(['a9', 'a10', 'b1'])
+  })
+
+  // The bank side has no voucher at all, and an unbooked ledger line has none
+  // either. Those must not push real rows out of view when the order flips.
+  it('keeps rows without a voucher last in both directions', () => {
+    const items = [
+      item({ item_id: 'none' }),
+      item({ item_id: 'a1', voucher_series: 'A', voucher_number: 1 }),
+    ]
+    expect(
+      sortReconciliationItems(items, { column: 'voucher', direction: 'asc' }).map((i) => i.item_id),
+    ).toEqual(['a1', 'none'])
+    expect(
+      sortReconciliationItems(items, { column: 'voucher', direction: 'desc' }).map((i) => i.item_id),
+    ).toEqual(['a1', 'none'])
+  })
+
+  // Matching means finding a counterpart with the opposite sign, so the sign
+  // has to survive the ordering: -103001 belongs below 35, not above it.
+  it('sorts amounts signed, not by magnitude', () => {
+    const items = [
+      item({ item_id: 'out', amount: -103001 }),
+      item({ item_id: 'small', amount: 35.24 }),
+      item({ item_id: 'in', amount: 11735.05 }),
+    ]
+    expect(
+      sortReconciliationItems(items, { column: 'amount', direction: 'asc' }).map((i) => i.item_id),
+    ).toEqual(['out', 'small', 'in'])
+  })
+
+  it('sorts descriptions with Swedish collation', () => {
+    const items = [
+      item({ item_id: 'o', description: 'Överföring' }),
+      item({ item_id: 'a', description: 'Avgift' }),
+      item({ item_id: 'z', description: 'Zettle' }),
+    ]
+    expect(
+      sortReconciliationItems(items, { column: 'description', direction: 'asc' }).map(
+        (i) => i.item_id,
+      ),
+    ).toEqual(['a', 'z', 'o'])
+  })
+
+  // Without a stable tie-break a refetch can reorder equal rows under the
+  // cursor, and in a matching view that means clicking the wrong verifikat.
+  it('breaks ties on item_id so the order is stable', () => {
+    const items = [
+      item({ item_id: 'zz', date: '2026-01-01' }),
+      item({ item_id: 'aa', date: '2026-01-01' }),
+    ]
+    const once = sortReconciliationItems(items, { column: 'date', direction: 'desc' })
+    const twice = sortReconciliationItems([...items].reverse(), { column: 'date', direction: 'desc' })
+    expect(once.map((i) => i.item_id)).toEqual(twice.map((i) => i.item_id))
+    expect(once.map((i) => i.item_id)).toEqual(['aa', 'zz'])
+  })
+})
+
+describe('nextReconSort', () => {
+  it('flips direction on the active column', () => {
+    expect(nextReconSort({ column: 'date', direction: 'desc' }, 'date')).toEqual({
+      column: 'date',
+      direction: 'asc',
+    })
+  })
+
+  it('opens dates and amounts descending, text ascending', () => {
+    expect(nextReconSort(DEFAULT_RECON_SORT, 'amount').direction).toBe('desc')
+    expect(nextReconSort(DEFAULT_RECON_SORT, 'description').direction).toBe('asc')
+    expect(nextReconSort(DEFAULT_RECON_SORT, 'voucher').direction).toBe('asc')
+  })
+})

--- a/lib/reconciliation/item-sort.ts
+++ b/lib/reconciliation/item-sort.ts
@@ -1,0 +1,101 @@
+import type { ReconciliationItem } from './schemas'
+
+/**
+ * Sorting for the manual match view's two tables.
+ *
+ * Pure and separate from the component because both tables share it and the
+ * matching flow is unforgiving: picking the wrong row books money against the
+ * wrong verifikat, so the ordering that leads the eye is worth testing.
+ *
+ * Not a general table sort. The ledger side has a voucher column the bank side
+ * does not, so a column that does not apply simply leaves the order untouched
+ * rather than throwing.
+ */
+export type ReconSortColumn = 'date' | 'voucher' | 'description' | 'amount'
+export type ReconSortDirection = 'asc' | 'desc'
+
+export interface ReconSort {
+  column: ReconSortColumn
+  direction: ReconSortDirection
+}
+
+/** Newest first: an unreconciled row is usually a recent one. */
+export const DEFAULT_RECON_SORT: ReconSort = { column: 'date', direction: 'desc' }
+
+const collator = new Intl.Collator('sv', { numeric: true, sensitivity: 'base' })
+
+/**
+ * Rows with nothing in the sorted column go last, in BOTH directions.
+ *
+ * This has to be decided before the direction factor is applied, not inside
+ * the comparator: multiplying it by -1 is exactly what would float the empty
+ * rows to the top on a descending sort, pushing the real ones out of view.
+ * Returns null when the rule does not apply and normal comparison should run.
+ */
+function emptyLast(
+  a: ReconciliationItem,
+  b: ReconciliationItem,
+  column: ReconSortColumn,
+): number | null {
+  if (column !== 'voucher') return null
+  const aHas = a.voucher_number != null
+  const bHas = b.voucher_number != null
+  if (aHas === bHas) return null
+  return aHas ? -1 : 1
+}
+
+/** Vouchers sort by series then number, not as text: 'A9' before 'A10'. */
+function compareVoucher(a: ReconciliationItem, b: ReconciliationItem): number {
+  const series = collator.compare(a.voucher_series ?? '', b.voucher_series ?? '')
+  if (series !== 0) return series
+  return (a.voucher_number ?? 0) - (b.voucher_number ?? 0)
+}
+
+function compare(a: ReconciliationItem, b: ReconciliationItem, column: ReconSortColumn): number {
+  switch (column) {
+    case 'date':
+      // ISO dates, so a plain string compare is chronological.
+      return a.date.localeCompare(b.date)
+    case 'voucher':
+      return compareVoucher(a, b)
+    case 'description':
+      return collator.compare(a.description, b.description)
+    case 'amount':
+      // Signed: an outgoing -103 001 sorts below an incoming 35. Matching is
+      // about finding a counterpart with the opposite sign, so keeping the
+      // sign visible in the order is what makes the two tables line up.
+      return a.amount - b.amount
+  }
+}
+
+/**
+ * Returns a new array; never mutates. The tie-break on item_id keeps the order
+ * stable across refetches, so a row does not jump under the cursor between two
+ * renders that both sort by the same column.
+ */
+export function sortReconciliationItems(
+  items: ReconciliationItem[],
+  sort: ReconSort,
+): ReconciliationItem[] {
+  const factor = sort.direction === 'asc' ? 1 : -1
+  return [...items].sort((a, b) => {
+    // Deliberately before the factor: see emptyLast.
+    const empty = emptyLast(a, b, sort.column)
+    if (empty !== null) return empty
+    const primary = compare(a, b, sort.column)
+    if (primary !== 0) return primary * factor
+    return a.item_id.localeCompare(b.item_id)
+  })
+}
+
+/**
+ * Header click: a new column starts ascending, except amount and date, where
+ * the useful first look is the largest or the most recent. Clicking the active
+ * column flips it.
+ */
+export function nextReconSort(current: ReconSort, column: ReconSortColumn): ReconSort {
+  if (current.column === column) {
+    return { column, direction: current.direction === 'asc' ? 'desc' : 'asc' }
+  }
+  return { column, direction: column === 'amount' || column === 'date' ? 'desc' : 'asc' }
+}


### PR DESCRIPTION
Matching a bank statement against the ledger means finding one row among two lists that are both fixed in whatever order the query returned. On an account with a few hundred open items that is the slow part of the work, and the view offered no way to reorder either side.

Date, voucher, event and amount are now sortable in both tables, with `aria-sort` on the header and a direction arrow.

Each table keeps its own sort rather than sharing one. The two sides hold different rows and the whole task is comparing them, so pinning both to the same order would work against the person doing the matching: you sort the bank side by amount to find the counterpart to a ledger row you are already looking at.

## Where the logic lives

The comparison is a pure function in `lib/reconciliation/item-sort.ts`, so the ordering rules are tested rather than inferred from the rendering. Nine tests cover them, including the one that is easy to get wrong: empty values sort last in **both** directions. Multiplying a nulls-last rule by the direction factor floats the empties to the top on descending, which is exactly when you are looking for the largest amounts and least want blank rows first.

Amounts compare numerically, dates and vouchers as strings, and the sort is stable so equal rows keep the order the query gave them.

Sorted copies are memoised so a re-render from selection state does not resort on every checkbox click, and selection is keyed by `item_id`, so reordering never disturbs what is picked.

## The header component

Deliberately local to this view rather than added to the shared list table. The matching tables are not on that table, because a selection in one constrains the other, so this borrows the idiom rather than the component. If the matching view moves onto the shared table later, this is the piece to delete.

## Scope

One new module with its tests, plus the wiring in the view. No migrations, no new dependencies, no API change. `npm run lint`, `check:types`, `check:guards`, `vitest run` and `npm run build` all green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added sortable headers to both reconciliation tables.
  * Each table now supports independent sorting by date, voucher, description, and amount.
  * Sort direction changes when selecting the active column, with clear handling for missing vouchers and stable results.

* **Bug Fixes**
  * Preserved selected reconciliation items while sorting.

* **Tests**
  * Added coverage for sort directions, ordering rules, missing values, localization, and stable results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->