### PR TITLE
fix(mfa): hard-navigate after TOTP verify, same race as #1984 on enroll

### DIFF
--- a/app/(auth)/mfa/verify/page.tsx
+++ b/app/(auth)/mfa/verify/page.tsx
@@ -145,20 +145,23 @@ function MfaVerifyContent() {
         return
       }
 
-      if (returnTo.startsWith('/api/')) {
-        // Route-handler destinations (e.g. the MCP OAuth consent page)
-        // return raw HTML the client router cannot render: hard-navigate.
-        window.location.assign(returnTo)
-        return
-      }
-
       // Hosted byrå staff hit MFA before any dashboard, so the cockpit
       // landing (WL-14) resolves here too: only when no explicit step-up
       // destination was requested. Everyone else keeps returnTo/'/' exactly
       // as before (the helper degrades to '/' on any failure). The session
       // is AAL2 at this point, so the /api MFA gate passes.
-      router.push(returnTo === '/' ? await resolvePostLoginDestination() : returnTo)
-      router.refresh()
+      //
+      // Always a hard navigation, for two reasons that point the same way.
+      // Route-handler destinations (e.g. the MCP OAuth consent page) return
+      // raw HTML the client router cannot render. And verifying raises the
+      // session to aal2, which lib/supabase/middleware.ts only re-evaluates
+      // on a fresh document request: `router.push` followed by
+      // `router.refresh` raced, the refresh won, and the user stayed on the
+      // code screen; re-entering the same code is then rejected as reuse and
+      // bumps the lockout counter (#2056, the shape #1984 fixed on enroll).
+      // returnTo went through safeReturnTo and the helper only ever returns
+      // '/clients' or '/', so the navigation stays same-origin.
+      window.location.assign(returnTo === '/' ? await resolvePostLoginDestination() : returnTo)
     } catch {
       toast({
         title: t('verify_failed_title'),


### PR DESCRIPTION
## What

`app/(auth)/mfa/verify/page.tsx`: after a successful `supabase.auth.mfa.verify`, the default path now hard-navigates with `window.location.assign(...)` instead of `router.push(...)` + `router.refresh()`. The separate `/api/` returnTo branch is folded into that one call. Nothing else on the page changes.

## Why

Verifying the challenge raises the session to aal2, which `lib/supabase/middleware.ts` only re-evaluates against a fresh document request. The client-side push raced the refresh; when the refresh won, the navigation landed nowhere and the user stayed on the code screen with a session that was already aal2. Re-entering the same TOTP code is rejected as reuse, which bumps the lockout counter and makes MFA look broken.

PR #1984 fixed the identical shape in `leave()` on `/mfa/enroll` (#1948) and explicitly listed this file as a possible follow-up. `/mfa/verify` is the page every hosted MFA user passes through on every login, so this is the higher-traffic sibling of that fix.

## How

- Same one-liner as #1984: `window.location.assign(returnTo === '/' ? await resolvePostLoginDestination() : returnTo)`.
- The `/api/` branch (`window.location.assign(returnTo)`) was a special case of the new line, so it is collapsed into it, mirroring what #1984 did to `leave()`.
- WL-14 cockpit landing preserved: `resolvePostLoginDestination()` is still awaited before navigating, the session is aal2 when its `/api/clients/landing` call runs, and the helper only ever returns `'/clients'` or `'/'`.
- Same-origin: `returnTo` still goes through `safeReturnTo()` first, so the unconditional hard navigation cannot leave the origin.
- The invite path keeps its own `window.location.href = '/'`: it deliberately ignores `returnTo`, so it is not the same shape.
- Comment updated to explain the hard navigation the way the enroll page does, with the #2056 / #1984 references.
- `router` is still used by the no-factor bounce and by logout, so the hook and import stay.

**Trade-off, already accepted.** A toast fired before `window.location.assign` is destroyed by the full page load (accepted in #1984 and in DECISIONS.md, 2026-07-26 invite-cookie entry). On this page the only success-path toast is the invite-problem warning in `acceptPendingInvite()`. One precision on the issue text: on the default (non-`/api/`) path that toast previously preceded a `router.push` and survived; after this change it does not. The invite cookie survives every non-definitive outcome, so `/onboarding` and `/select-company` retry acceptance server-side and the invitee is not stranded; the message is what is lost, exactly as on enroll and on the `?returnTo=` path today.

## Verification

- `npm run check:lint`: OK, 0 errors, baseline 0.
- `npx vitest run 'app/(auth)'`: 7 files, 74 tests passed (no component tests exist for this page; expected).
- `npm run check:types`: the changed file has zero tsc errors. The ratchet reports one unrelated pre-existing error in `extensions/general/email/lib/smtp-service.ts` (TS7016, missing `nodemailer` declarations) because the local worktree's shared `node_modules` lacks `@types/nodemailer` even though `package.json` lists it; CI runs `npm ci` and is unaffected.
- No `@/extensions/` imports in core (`grep` guard clean).
- No em or en dashes in the diff.

## Out of scope

Nothing else on the page: the `finally { setIsLoading(false) }` that briefly re-enables the button between `assign()` and unload is pre-existing on the invite and `/api/` paths (and on enroll), and the invite path's own hard navigation is untouched.

Fixes #2056

## First principles

**Why the problem occurred.** Verifying the challenge raises the session to aal2, and the middleware only re-evaluates that on a document request. Any client-side navigation after an auth-state change is racy by construction; #1984 diagnosed it on enroll and this page kept the old shape.

**What removal was considered.** The fix is itself a removal: the special `/api/` branch and the push-plus-refresh pair collapse into one hard navigation. The larger alternative, turning verify into a server action that redirects so the client never navigates, was not taken: it rewrites a page with no reported failure to reach the same mechanism a hard navigation already gives.

**Why this shape.** Same precedent as #1984, fewer branches than before, and the same-origin guarantee stays in `safeReturnTo`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015qgLgdt4mLmha1ZLFMwq1u

