### PR TITLE
docs(claude): fix from first principles before implementing a proposed solution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,16 @@ General prohibitions:
 - **Swedish domain questions are never answered from training data.** Load the matching `swedish-*` skill (vat, accounting-compliance, invoice-compliance, payroll, year-end-closing, sie-import-export, sru-filing, financial-reporting, asset-accounting, project-accounting, tax-planning, e-invoicing).
 - Scaffolding has skills; use them instead of improvising: `/erp-api-route` (API routes), `/supabase-migration` (migrations), `/create-extension` (extensions), `/frontend-design` (new UI), `vercel:deploy` (deployment).
 
+## Fix From First Principles
+
+A reported problem usually arrives with a proposed solution: the reporter's workaround, the issue author's fix shape, the obvious patch at the line that broke. Treat it as evidence about the pain, not as the spec. Before implementing, answer three questions and put the answers in the PR body:
+
+1. **Why did the problem occur?** Name the mechanism, not the symptom. A wrong number in one place usually means the definition lives in several places; a bypassed check usually means the invariant lives only in application code; a confusing label usually means a field nobody reads. Fix at the level that stops the class of bug, not the instance that was reported.
+2. **What could be removed or simplified instead?** A counter that cannot be wrong because it is gone, a policy dropped instead of a check added, one write path instead of a third copy of a formula, a constraint instead of a trigger. The solution with fewer states and less code wins unless something concrete needs the extra state.
+3. **Is this the best solution, or just the proposed one?** Write down the alternative you considered and why you did not take it. When the better answer removes or changes something users see (a column, a field, a limit), state both options with a recommendation: that choice is the founder's, and the PR should make it easy to take either way.
+
+When the chosen path differs from the one proposed in the issue, record it in `DECISIONS.md` (see Decision Log).
+
 ## Definition of Done
 
 A change is done when all of these hold; iterate until they do:
@@ -49,6 +59,7 @@ A change is done when all of these hold; iterate until they do:
 7. Commit is conventional (`feat:`/`fix:`/`refactor:`/`test:`/`docs:`), atomic, branched from `main`.
 8. If the change touches migrations, local and prod are reconciled: every version in prod's `schema_migrations` has a matching file in `supabase/migrations/`, and vice versa. Check before opening the PR (e.g. `list_migrations` / `select version from supabase_migrations.schema_migrations`); a remote-only version means an uncommitted orphan that will fail the merge.
 9. **The last mile is verified in-session, not assumed.** Whatever was built is confirmed switched on before the session ends: merged PR's migration applied to prod, scheduled loop/routine observed firing, script actually executed, feature reachable. If switch-on must wait, the session's final output states exactly what is NOT live yet and who flips it. History shows the expensive failure mode is built-but-never-initiated, not built-wrong.
+10. The PR body answers the three questions in [Fix From First Principles](#fix-from-first-principles): why the problem occurred, what removal or simplification was considered, and why the chosen solution is the best one rather than the proposed one.
 
 ## Commands
 


### PR DESCRIPTION
## What

A new CLAUDE.md section, **Fix From First Principles**, plus Definition of Done item 10 that requires PR bodies to carry the answers.

## Why

Issue fixes tend to implement the solution the report proposed. The report is evidence about the pain, not the spec. The principle asks three questions before implementing: why did the problem occur (mechanism, not symptom), what could be removed or simplified instead, and is this the best solution or just the proposed one. Product-visible removals are stated as options with a recommendation, since that choice is the founder's.

## How

Text only; no code changes. Applied retroactively to the 2026-09-04 ten-issue batch (#2272 through #2282), where it changed the shape of several fixes: a counter removed instead of made filter-aware, a CHECK constraint instead of a trigger, one payment-row writer instead of a shared amount helper, and logging reduced to code + message instead of redacted free text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015qgLgdt4mLmha1ZLFMwq1u


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added contributor guidance encouraging root-cause analysis, simplification, and documentation of alternatives.
  * Updated the Definition of Done to require answering three decision-making questions in pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->