### PR TITLE
fix(ui): clip the flexible list cell on the rows #2003 missed

### DIFF
--- a/app/(dashboard)/customers/page.tsx
+++ b/app/(dashboard)/customers/page.tsx
@@ -352,7 +352,9 @@ function CustomersPageInner() {
                       className="group cursor-pointer transition-colors duration-150 hover:bg-secondary/35"
                       onClick={() => router.push(`/customers/${customer.id}`)}
                     >
-                      <td className={cn(TD_CLASS, 'max-w-0 w-full')}>
+                      {/* overflow-hidden: see #2003, the shrink-0 verified
+                          badge cannot truncate. */}
+                      <td className={cn(TD_CLASS, 'max-w-0 w-full overflow-hidden')}>
                         <span className="flex min-w-0 items-center gap-2">
                           <Link
                             href={`/customers/${customer.id}`}

--- a/app/(dashboard)/salary/page.tsx
+++ b/app/(dashboard)/salary/page.tsx
@@ -213,7 +213,9 @@ export default function SalaryPage() {
                             {periodOf(run)}
                           </Link>
                         </td>
-                        <td className={cn(TD_CLASS, 'max-w-0 w-full whitespace-nowrap')}>
+                        {/* overflow-hidden: see #2003, nothing in this cell
+                            truncates so it must clip. */}
+                        <td className={cn(TD_CLASS, 'max-w-0 w-full overflow-hidden whitespace-nowrap')}>
                           <span className="inline-flex items-center gap-2">
                             {run.status === 'booked' ? (
                               <span className="text-muted-foreground">{t('status_booked')}</span>

--- a/components/bookkeeping/ChartOfAccountsManager.tsx
+++ b/components/bookkeeping/ChartOfAccountsManager.tsx
@@ -748,7 +748,9 @@ export default function ChartOfAccountsManager() {
                               <td className={cn(TD_CLASS, 'whitespace-nowrap tabular-nums')}>
                                 <AccountNumber number={account.account_number} name={account.account_name} />
                               </td>
-                              <td className={cn(TD_CLASS, 'max-w-0 w-full')}>
+                              {/* overflow-hidden: see #2003, the shrink-0
+                                  markers cannot truncate. */}
+                              <td className={cn(TD_CLASS, 'max-w-0 w-full overflow-hidden')}>
                                 <span className="flex min-w-0 items-center gap-1.5">
                                   <span className="truncate">{account.account_name}</span>
                                   {account.is_system_account && (

--- a/components/bookkeeping/JournalEntryList.tsx
+++ b/components/bookkeeping/JournalEntryList.tsx
@@ -1597,7 +1597,9 @@ export default function JournalEntryList({
                       <td className={cn(TD_CLASS, 'hidden sm:table-cell whitespace-nowrap tabular-nums text-muted-foreground', struckCell)}>
                         {formatDate(entry.entry_date)}
                       </td>
-                      <td className={cn(TD_CLASS, 'max-w-0 w-full')}>
+                      {/* overflow-hidden: see #2003, the shrink-0 status
+                          chips cannot truncate and would paint over Belopp. */}
+                      <td className={cn(TD_CLASS, 'max-w-0 w-full overflow-hidden')}>
                         <span className="flex min-w-0 items-center gap-2">
                           <span className={cn('truncate', struckCell)}>{entry.description}</span>
                           {entry.out_of_period && (

--- a/components/transactions/SkattekontoInboxCard.tsx
+++ b/components/transactions/SkattekontoInboxCard.tsx
@@ -102,7 +102,11 @@ export default function SkattekontoInboxCard({
       <td className={cn(TD_CLASS, '!pl-0 whitespace-nowrap tabular-nums text-muted-foreground')}>
         {formatDate(row.transaktionsdatum)}
       </td>
-      <td className={cn(TD_CLASS, 'max-w-0 w-full')}>
+      {/* overflow-hidden: the shrink-0 chips below don't truncate, so on a
+          viewport too narrow for them the cell must clip instead of painting
+          over the Belopp column. Same guard #2003 put on TransactionInboxCard;
+          this row and the ones below never got it. */}
+      <td className={cn(TD_CLASS, 'max-w-0 w-full overflow-hidden')}>
         <span className="row-collapsible flex min-w-0 items-center gap-2">
           <span className="truncate">{row.transaktionstext}</span>
           <Badge variant="outline" className="h-4 shrink-0 gap-1 px-1.5 py-0 text-[10px] font-normal">

--- a/components/transactions/TransactionHistoryList.tsx
+++ b/components/transactions/TransactionHistoryList.tsx
@@ -318,7 +318,9 @@ function BankHistoryRow({
       <td className={cn(TD_CLASS, '!pl-0 whitespace-nowrap tabular-nums text-muted-foreground')}>
         {formatDate(transaction.date)}
       </td>
-      <td className={cn(TD_CLASS, 'max-w-0 w-full')}>
+      {/* overflow-hidden: see #2003, the shrink-0 markers below cannot
+          truncate and would paint over Belopp. */}
+      <td className={cn(TD_CLASS, 'max-w-0 w-full overflow-hidden')}>
         <span className="row-collapsible flex min-w-0 items-center gap-2">
           <span className="truncate">{transaction.description}</span>
           <TransactionAttachmentIndicator
@@ -490,7 +492,8 @@ function SkattekontoHistoryRow({
       <td className={cn(TD_CLASS, '!pl-0 whitespace-nowrap tabular-nums text-muted-foreground')}>
         {formatDate(row.transaktionsdatum)}
       </td>
-      <td className={cn(TD_CLASS, 'max-w-0 w-full')}>
+      {/* overflow-hidden: see the bank row above. */}
+      <td className={cn(TD_CLASS, 'max-w-0 w-full overflow-hidden')}>
         <span className="flex min-w-0 items-center gap-2">
           <span className="truncate">{row.transaktionstext}</span>
           <Badge variant="outline" className="h-4 shrink-0 gap-1 px-1.5 py-0 text-[10px] font-normal">


### PR DESCRIPTION
# What and why

Six list rows get `overflow-hidden` on their flexible `max-w-0 w-full` cell, the guard #2003 already gave `TransactionInboxCard`. Nothing else changes: no columns removed, no widths altered, no strings touched.

#2003 added that guard because the row's `shrink-0` markers cannot truncate: past the width that fits them, the cell painted over the Belopp column instead of clipping. Every other row built on the same hand-copied pattern still has the bug.

Reported from a self-hosted instance on /transactions, on a Skatteverket row whose booking suggestion is long ("Bokförs mot 2731 Avräkning lagstadgade sociala avgifter"): the text runs straight through the amount, so the row's value is unreadable.

**Not engine specific.** Reproduced in both Chrome and Firefox on the same build. Firefox does reach it sooner, because `max-width` on a `<td>` is undefined per CSS 2.1 10.4 and Firefox ignores it when sizing columns, so the `max-w-0` cap that holds the cell back in Blink does nothing there. That divergence is a separate bug, fixed in #2285, not here. This PR only makes the cell clip, which is correct in every engine.

**Rows fixed**

- `components/transactions/SkattekontoInboxCard.tsx` (the reported one)
- `components/transactions/TransactionHistoryList.tsx`, both the bank row and the skattekonto row
- `components/bookkeeping/JournalEntryList.tsx`
- `components/bookkeeping/ChartOfAccountsManager.tsx`, the "Mina konton" row
- `app/(dashboard)/customers/page.tsx`
- `app/(dashboard)/salary/page.tsx`

**Deliberately not fixed.** `ChartOfAccountsManager`'s second flexible cell (the BAS catalog row) holds a single truncating child and nothing that refuses to shrink, so it has nothing to clip.

**Rendered evidence.** On a self-hosted instance running this fix, the previously overlapping row clips at the cell edge and the amount is fully readable. Confirmed in Firefox 155 on real data; the Chrome reproduction is from the same instance before the fix. I could not measure this locally, because the checkout has no `.env.local` and the dev server 503s every path, so the evidence is from a deployed instance rather than a headless run.

**Follow-up worth considering.** The pattern (`max-w-0 w-full` plus an inner `flex min-w-0` mixing truncating and non-truncating children) is hand-copied into every list row, which is why #2003 fixed one instance and left six. A `TD_FLEX_CLASS` in `components/ui/dry-table.tsx` beside `TD_CLASS`, carrying `max-w-0 w-full overflow-hidden`, would make the guard unforgettable. Not attempted here to keep the diff to the fix; happy to follow up.

## Checklist

- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `refactor:`, `test:`, `docs:`)
- [x] `npm run lint`, `npm test`, and `npm run build` pass locally
- [x] New or changed logic in `lib/` or `app/api/` has tests
- [x] New or changed UI strings exist in both `messages/sv.json` and `messages/en.json`
- [x] Migrations (if any) are new files in `supabase/migrations/`; no edits to already-shipped migrations
- [x] Core builds with zero extensions enabled (no imports from `@/extensions/` in core code)
- [x] Commits are signed off (`git commit -s`, see [DCO](../DCO))

**Notes on the checklist, so the ticks are not read as more than they are:**

- `npm run lint` 0 errors, `npm run build` compiles, `npm run check:types` OK at 535 against baseline 535, `npm run check:guards` passed.
- `npm test`: 21006 passed, 10 failed. Those 10 fail identically on unmodified `main` (verified at db289e3bd) and are environment-specific to this Windows checkout: `bash -n` on the self-host shell scripts, Windows path separators in the v1 scope-registry parity test, and three `scripts/checks` suites that fail to load. None of them touch the files in this diff.
- No `lib/` or `app/api/` logic changed, so no tests were added; this is six className changes in components, and the repo does not carry component tests.
- No UI strings added or changed. No migrations. No `@/extensions/` imports (0 in the diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved table and list layouts by clipping overflowing names, descriptions, statuses, and badges.
  * Prevented content from overlapping adjacent amount columns, particularly on narrow screens.
  * Preserved visibility and positioning of verification badges and status markers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->