### PR TITLE
fix(ui): stop table cells sizing their column by max-width (Firefox)

### DIFF
--- a/app/(dashboard)/customers/page.tsx
+++ b/app/(dashboard)/customers/page.tsx
@@ -374,8 +374,11 @@ function CustomersPageInner() {
                       <td className={cn(TD_CLASS, 'hidden whitespace-nowrap tabular-nums text-muted-foreground lg:table-cell')}>
                         {identifier || ''}
                       </td>
-                      <td className={cn(TD_CLASS, 'hidden max-w-[220px] truncate text-muted-foreground md:table-cell')}>
-                        {customer.email || ''}
+                      {/* See the suppliers list: the cap must sit on an inner
+                          block because Firefox ignores max-width on a td, and
+                          188 = 220 minus the cell's px-4. */}
+                      <td className={cn(TD_CLASS, 'hidden text-muted-foreground md:table-cell')}>
+                        <div className="max-w-[188px] truncate">{customer.email || ''}</div>
                       </td>
                       <td className={cn(TD_CLASS, 'hidden whitespace-nowrap text-muted-foreground sm:table-cell')}>
                         {customer.city || ''}

--- a/app/(dashboard)/orders/page.tsx
+++ b/app/(dashboard)/orders/page.tsx
@@ -538,15 +538,17 @@ function OrderRow({
           <span>{order.order_number}</span>
         )}
       </td>
+      {/* Cap on an inner block: Firefox ignores max-width on a td when sizing
+          columns. 128 = the old 160 minus the cell's px-4. */}
       {multiStore && (
-        <td className={cn(TD_CLASS, 'max-w-[160px] truncate text-muted-foreground')}>
-          {order.store_label || order.store_scope}
+        <td className={cn(TD_CLASS, 'text-muted-foreground')}>
+          <div className="max-w-[128px] truncate">{order.store_label || order.store_scope}</div>
         </td>
       )}
       {/* One-line rows (design convention 4): the full beställningsuppgifter
           (kontaktperson, orgnr, e-post) live in the native tooltip. */}
       <td
-        className={cn(TD_CLASS, 'max-w-[220px] truncate')}
+        className={TD_CLASS}
         title={
           [
             order.customer_company ? order.customer_name : null,
@@ -557,9 +559,12 @@ function OrderRow({
             .join(' · ') || undefined
         }
       >
-        {order.customer_company || order.customer_name || (
-          <span className="text-muted-foreground">{'–'}</span>
-        )}
+        {/* 188 = the old 220 cap minus the cell's px-4; see the store cell. */}
+        <div className="max-w-[188px] truncate">
+          {order.customer_company || order.customer_name || (
+            <span className="text-muted-foreground">{'–'}</span>
+          )}
+        </div>
       </td>
       <td className={cn(TD_CLASS, 'whitespace-nowrap text-muted-foreground')}>
         {order.payment_method_title || order.payment_method || ''}

--- a/app/(dashboard)/skattekonto/page.tsx
+++ b/app/(dashboard)/skattekonto/page.tsx
@@ -1106,7 +1106,9 @@ function MatchDialog({
   const open = !!row
   return (
     <Dialog open={open} onOpenChange={o => !o && onClose()}>
-      <DialogContent className="max-w-2xl">
+      {/* See SkattekontoMatchDialog for why 3xl and why the table below is
+          fixed layout. */}
+      <DialogContent className="max-w-3xl">
         <DialogHeader>
           <DialogTitle>Matcha mot befintligt verifikat</DialogTitle>
           {/* data-ph-mask: transaction text and amount are user data */}
@@ -1142,14 +1144,14 @@ function MatchDialog({
 
         {!loading && candidates && candidates.length > 0 && (
           <div className="max-h-[420px] overflow-y-auto rounded-lg border">
-            <Table>
+            <Table className="table-fixed min-w-[470px] sm:min-w-[580px]">
               <TableHeader>
                 <TableRow>
-                  <TableHead>Datum</TableHead>
-                  <TableHead>Verifikat</TableHead>
+                  <TableHead className="w-[116px]">Datum</TableHead>
+                  <TableHead className="w-[128px]">Verifikat</TableHead>
                   <TableHead>Beskrivning</TableHead>
-                  <TableHead>Status</TableHead>
-                  <TableHead></TableHead>
+                  <TableHead className="hidden w-[112px] sm:table-cell">Status</TableHead>
+                  <TableHead className="sticky right-0 w-[124px] bg-background sm:static sm:bg-transparent"></TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
@@ -1159,10 +1161,10 @@ function MatchDialog({
                     <TableCell className="tabular-nums">
                       {formatVoucher(c)}
                     </TableCell>
-                    <TableCell className="max-w-[260px] truncate">
-                      {c.description}
-                    </TableCell>
                     <TableCell>
+                      <div className="truncate">{c.description}</div>
+                    </TableCell>
+                    <TableCell className="hidden sm:table-cell">
                       {c.status === 'posted' ? (
                         <Badge variant="secondary">Bokförd</Badge>
                       ) : c.status === 'draft' ? (
@@ -1171,7 +1173,7 @@ function MatchDialog({
                         <Badge variant="destructive">Makulerad</Badge>
                       )}
                     </TableCell>
-                    <TableCell className="text-right">
+                    <TableCell className="sticky right-0 bg-background text-right sm:static sm:bg-transparent">
                       <Button
                         size="sm"
                         onClick={() => onConfirm(c.journal_entry_id)}

--- a/app/(dashboard)/suppliers/page.tsx
+++ b/app/(dashboard)/suppliers/page.tsx
@@ -244,8 +244,14 @@ export default function SuppliersPage() {
                       <td className={cn(TD_CLASS, 'hidden whitespace-nowrap tabular-nums text-muted-foreground sm:table-cell')}>
                         {payment ? `${payment.label} ${payment.value}` : ''}
                       </td>
-                      <td className={cn(TD_CLASS, 'hidden max-w-[220px] truncate text-muted-foreground md:table-cell')}>
-                        {supplier.email || ''}
+                      {/* The cap sits on an inner block, not the td: max-width
+                          on a table cell is undefined per CSS 2.1 10.4 and
+                          Firefox ignores it when sizing columns, so a long
+                          address widened the table there. 188 = the old 220
+                          minus the cell's px-4, which the border-box cap on
+                          the td used to include, so the column is unchanged. */}
+                      <td className={cn(TD_CLASS, 'hidden text-muted-foreground md:table-cell')}>
+                        <div className="max-w-[188px] truncate">{supplier.email || ''}</div>
                       </td>
                       <td className={cn(TD_CLASS, 'hidden whitespace-nowrap tabular-nums text-muted-foreground lg:table-cell')}>
                         {supplier.org_number || ''}

--- a/components/skattekonto/SkattekontoMatchDialog.tsx
+++ b/components/skattekonto/SkattekontoMatchDialog.tsx
@@ -144,7 +144,10 @@ export function SkattekontoMatchDialog({
 
   return (
     <Dialog open={open} onOpenChange={o => !o && onClose()}>
-      <DialogContent className="max-w-2xl">
+      {/* 3xl, not 2xl: the five fixed columns below claim 480px, and at 2xl
+          that left the description under 150px, too narrow to tell two
+          candidates apart. */}
+      <DialogContent className="max-w-3xl">
         <DialogHeader>
           <DialogTitle>{t('title')}</DialogTitle>
           {/* data-ph-mask: transaction text and amount are user data */}
@@ -177,16 +180,29 @@ export function SkattekontoMatchDialog({
           </div>
         )}
 
+        {/* table-fixed, not auto layout: with auto layout the column widths
+            come from the content, and the candidate rows sat right at the
+            dialog's width. Firefox keeps the date on one line where Chrome
+            wraps it, and ignores max-width on a td, so the table overflowed
+            there and pushed the Koppla button out of reach. Fixed layout makes
+            the widths the same in every engine.
+            Below sm the dialog is only as wide as the viewport, which cannot
+            hold all five columns: Status drops out (it reads "Bokförd" on
+            nearly every candidate anyway, design convention 5) and the action
+            cell pins to the right edge, so Koppla stays on screen however
+            narrow the window gets. sm:static restores a plain cell on pointer
+            devices, where a pinned opaque background would not pick up the
+            row hover tint. */}
         {!loading && candidates && candidates.length > 0 && (
           <div className="max-h-[420px] overflow-y-auto rounded-lg border">
-            <Table>
+            <Table className="table-fixed min-w-[470px] sm:min-w-[580px]">
               <TableHeader>
                 <TableRow>
-                  <TableHead>{t('th_date')}</TableHead>
-                  <TableHead>{t('th_voucher')}</TableHead>
+                  <TableHead className="w-[116px]">{t('th_date')}</TableHead>
+                  <TableHead className="w-[128px]">{t('th_voucher')}</TableHead>
                   <TableHead>{t('th_description')}</TableHead>
-                  <TableHead>{t('th_status')}</TableHead>
-                  <TableHead></TableHead>
+                  <TableHead className="hidden w-[112px] sm:table-cell">{t('th_status')}</TableHead>
+                  <TableHead className="sticky right-0 w-[124px] bg-background sm:static sm:bg-transparent"></TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
@@ -196,10 +212,12 @@ export function SkattekontoMatchDialog({
                     <TableCell className="tabular-nums">
                       {formatVoucher(c)}
                     </TableCell>
-                    <TableCell className="max-w-[260px] truncate">
-                      {c.description}
-                    </TableCell>
+                    {/* No width cap: the column is sized by the fixed layout
+                        above, so the block just fills it and clips. */}
                     <TableCell>
+                      <div className="truncate">{c.description}</div>
+                    </TableCell>
+                    <TableCell className="hidden sm:table-cell">
                       {c.status === 'posted' ? (
                         <Badge variant="secondary">{t('status_posted')}</Badge>
                       ) : c.status === 'draft' ? (
@@ -208,7 +226,7 @@ export function SkattekontoMatchDialog({
                         <Badge variant="destructive">{t('status_reversed')}</Badge>
                       )}
                     </TableCell>
-                    <TableCell className="text-right">
+                    <TableCell className="sticky right-0 bg-background text-right sm:static sm:bg-transparent">
                       <Button
                         size="sm"
                         onClick={() => confirmMatch(c.journal_entry_id)}

--- a/components/supplier-invoices/PaymentFileDialog.tsx
+++ b/components/supplier-invoices/PaymentFileDialog.tsx
@@ -268,8 +268,10 @@ export default function PaymentFileDialog({
                         <td className="whitespace-nowrap py-2 pr-3 tabular-nums">
                           {line.payee.label}
                         </td>
-                        <td className="max-w-[120px] truncate whitespace-nowrap py-2 pr-3 tabular-nums text-muted-foreground">
-                          {line.reference.value}
+                        {/* Cap on an inner block: Firefox ignores max-width on
+                            a td when sizing columns. 108 = 120 minus pr-3. */}
+                        <td className="py-2 pr-3 tabular-nums text-muted-foreground">
+                          <div className="max-w-[108px] truncate">{line.reference.value}</div>
                         </td>
                         <td className="whitespace-nowrap py-2 pr-3">
                           <Input

--- a/components/transactions/BulkBookDialog.tsx
+++ b/components/transactions/BulkBookDialog.tsx
@@ -797,8 +797,10 @@ export default function BulkBookDialog({
                     {previewLines.slice(0, 30).map((line, i) => (
                       <tr key={i} className="border-b border-border/40 last:border-b-0">
                         <td className="px-3 py-1.5 font-mono">{line.account_number}</td>
-                        <td className="px-3 py-1.5 text-muted-foreground truncate max-w-[240px]">
-                          {line.line_description ?? '-'}
+                        {/* Cap on an inner block: Firefox ignores max-width on
+                            a td when sizing columns. 216 = 240 minus px-3. */}
+                        <td className="px-3 py-1.5 text-muted-foreground">
+                          <div className="max-w-[216px] truncate">{line.line_description ?? '-'}</div>
                         </td>
                         <td className="px-3 py-1.5 text-right">
                           {line.debit_amount > 0 ? formatCurrency(line.debit_amount) : ''}


### PR DESCRIPTION
# What and why

`max-w-[Npx] truncate` written straight onto a `<td>` moves to a block inside the cell, on six lists and dialogs. The Skattekonto match dialog additionally moves to a fixed table layout. Rendered column widths on the six are unchanged in Chrome; Firefox now matches them.

`max-width` on a table cell is undefined per CSS 2.1 10.4. Blink applies it, Firefox does not when computing column widths. So the cap worked in Chrome and did nothing in Firefox, and because `truncate` also sets `white-space: nowrap`, the cell's min-content width in Firefox is the entire string. The table then grows past whatever contains it.

Worst case is the Skattekonto match dialog, reported from a self-hosted instance on Firefox 155: the candidate table outgrew the dialog and pushed the **Koppla** button past the edge, so the dialog's only action was unreachable. The same dialog in Chrome, same build, fits.

This is a different bug from #2262 / #2281 (a page list whose eight nowrap columns exceed the 960px content column). Same family, different cause: here the column cap is simply not applied. It is also distinct from #2284, which makes overflowing cells clip; this one stops them overflowing in the first place.

**The cap moves to an inner block, minus the padding.** Tailwind sets `box-sizing: border-box`, so a `max-width` on the td included the cell's own padding. On an inner block it does not, so each cap is reduced by that padding and the column comes out exactly as wide as before:

| | was (on td) | now (inner block) | cell padding |
|---|---|---|---|
| suppliers, customers e-post | 220 | 188 | `px-4` |
| orders butik | 160 | 128 | `px-4` |
| orders kund | 220 | 188 | `px-4` |
| BulkBookDialog beskrivning | 240 | 216 | `px-3` |
| PaymentFileDialog referens | 120 | 108 | `pr-3` |

**The match dialog needed more.** Its table sat right at the dialog's width with columns sized by content, so restoring the cap alone would leave it one long verifikat number from overflowing again, at a different threshold per engine (Firefox keeps the date on one line where Chrome wraps it). It is now `table-fixed` with explicit widths, which removes content and engine from the calculation:

- 116 / 128 / rest / 112 / 124, and `max-w-3xl` instead of `2xl` because five fixed columns leave the description under 150px at `2xl`.
- Below `sm` the viewport cannot hold five columns, so Status drops out and the action cell becomes `sticky right-0`. The button cannot leave the screen at any width; `sm:static` gives pointer devices a plain cell again so the row hover tint still covers it.

**Measured, not assumed.** On a self-hosted instance with real data, Firefox 155: at a 1579px viewport the wrapper and table are both 718px, overflow 0, columns 116 / 128 / 237 / 112 / 124, Koppla inside the dialog. At 500px the table is held at its 470px minimum against a 448px wrapper, Status is gone and Koppla is still on screen. Before this change the same dialog scrolled sideways with the button off the edge. I could not run a headless measurement locally (this checkout has no `.env.local`, so the dev server 503s every path), which is why the numbers come from a deployed instance.

I also checked the compiled CSS directly, because a Tailwind JIT miss on an arbitrary value would have made this silently inert: every value is present (`w-[116px]`, `min-w-[470px]`, `max-w-[188px]`, …), `.sticky{position:sticky}` is global, and `.sm\:static` / `.sm\:table-cell` / `.sm\:min-w-[580px]` sit inside `@media (min-width:40rem)`.

**Two taste calls, easy to flip.** Both are in the match dialog and neither is load-bearing for the bug:

1. `max-w-3xl` rather than keeping `2xl` and accepting a ~150px description column.
2. Dropping **Status** below `sm` rather than one of the other four. It reads "Bokförd" on nearly every candidate, which design convention 5 already calls a sign the chip is wrong there, so it looked like the least load-bearing column.

**Follow-up worth considering.** `check:guards` already has a `dialog-overflow-risk` family for "patterns that make a dialog scroll sideways", and `max-width` on a `<td>` is a new member it does not catch. I kept it out of this PR so a guard change is not bundled into a bug fix, but it is a small rule and I am happy to follow up. The alternative general fix, `table-fixed` everywhere, was rejected: it needs an explicit width for every column on ~25 list pages, and #2125 shows fixed widths that are too wide cause their own overflow.

## Checklist

- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `refactor:`, `test:`, `docs:`)
- [x] `npm run lint`, `npm test`, and `npm run build` pass locally
- [x] New or changed logic in `lib/` or `app/api/` has tests
- [x] New or changed UI strings exist in both `messages/sv.json` and `messages/en.json`
- [x] Migrations (if any) are new files in `supabase/migrations/`; no edits to already-shipped migrations
- [x] Core builds with zero extensions enabled (no imports from `@/extensions/` in core code)
- [x] Commits are signed off (`git commit -s`, see [DCO](../DCO))

**Notes on the checklist, so the ticks are not read as more than they are:**

- `npm run lint` 0 errors, `npm run build` compiles, `npm run check:types` OK at 535 against baseline 535, `npm run check:guards` passed.
- `npm test`: 21006 passed, 10 failed. Those 10 fail identically on unmodified `main` (verified at db289e3bd) and are environment-specific to this Windows checkout: `bash -n` on the self-host shell scripts, Windows path separators in the v1 scope-registry parity test, and three `scripts/checks` suites that fail to load. None of them touch the files in this diff.
- No `lib/` or `app/api/` logic changed, so no tests were added; this is className and markup structure in components, and the repo does not carry component tests.
- No UI strings added or changed. No migrations. No `@/extensions/` imports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
