### PR TITLE
fix(settings): show series names in the verifikationsserie per typ picker

### DIFF
--- a/components/settings/VoucherSeriesPerSourceTypeForm.tsx
+++ b/components/settings/VoucherSeriesPerSourceTypeForm.tsx
@@ -84,12 +84,19 @@ export function VoucherSeriesPerSourceTypeForm({ settings, onSettingsUpdated }: 
   const [showAll, setShowAll] = useState(false)
 
   // Same closed list as the manual verifikat form and the per-bankkonto
-  // picker: the fixed Swedish presets, then any letter the company already
-  // uses that the presets do not cover, so no saved value falls out of the
-  // list. A free A-Z list would let a typo start an undocumented series.
+  // picker: the fixed Swedish presets, then any letter already configured in
+  // settings that the presets do not cover. The saved map is read alongside
+  // the draft so a non-preset letter stays selectable after the user changes
+  // that row away from it (otherwise a misclick could not be undone without
+  // a reload) and so a letter that lands in settings after mount is offered.
+  // A free A-Z list would let a typo start an undocumented series.
   const seriesOptions = useMemo(() => {
     const preset = new Set(VOUCHER_SERIES_PRESETS.map((p) => p.letter))
-    const extras = [settings.default_voucher_series, ...Object.values(draft)].filter(
+    const extras = [
+      settings.default_voucher_series,
+      ...Object.values(settings.default_voucher_series_per_source_type ?? {}),
+      ...Object.values(draft),
+    ].filter(
       (v): v is string => typeof v === 'string' && SERIES_LETTER_RE.test(v) && !preset.has(v),
     )
     const uniqueExtras = Array.from(new Set(extras)).sort()
@@ -97,7 +104,7 @@ export function VoucherSeriesPerSourceTypeForm({ settings, onSettingsUpdated }: 
       ...VOUCHER_SERIES_PRESETS,
       ...uniqueExtras.map((letter) => ({ letter, label: '' })),
     ]
-  }, [settings.default_voucher_series, draft])
+  }, [settings.default_voucher_series, settings.default_voucher_series_per_source_type, draft])
 
   const handleChange = (sourceType: JournalEntrySourceType, value: string) => {
     setDraft((prev) => ({ ...prev, [sourceType]: value }))
@@ -174,7 +181,7 @@ export function VoucherSeriesPerSourceTypeForm({ settings, onSettingsUpdated }: 
   return (
     <SettingsGroup
       label="Verifikationsserier per typ"
-      help="Tilldela en standardserie per typ av verifikat. Vanlig svensk praxis: kundfakturor på serie B, leverantörsfakturor på serie D, löner på serie K, övrigt på serie A. Kan alltid ändras per verifikat när du bokför."
+      help="Tilldela en standardserie per typ av verifikat. Namnen i listan följer Fortnox-konventionen: kundfakturor på serie B, leverantörsfakturor på serie D, löner på serie K, övrigt på serie A. Andra program använder andra bokstäver; bokstaven är ett fritt val. Kan alltid ändras per verifikat när du bokför."
     >
       {alwaysVisible.map((entry, i) =>
         // The last always-visible row sits right above the fold toggle:

--- a/components/settings/VoucherSeriesPerSourceTypeForm.tsx
+++ b/components/settings/VoucherSeriesPerSourceTypeForm.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { useTranslations } from 'next-intl'
 import { Button } from '@/components/ui/button'
 import { useToast } from '@/components/ui/use-toast'
@@ -13,9 +13,10 @@ import {
 } from '@/components/settings/SettingsRows'
 import { cn } from '@/lib/utils'
 import { getErrorMessage } from '@/lib/errors/get-error-message'
+import { VOUCHER_SERIES_PRESETS } from '@/lib/bookkeeping/voucher-series-resolver'
 import type { CompanySettings, JournalEntrySourceType } from '@/types'
 
-const SERIES_OPTIONS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('')
+const SERIES_LETTER_RE = /^[A-Z]$/
 
 // Subset of source_types presented to the user. The DB column accepts every
 // JournalEntrySourceType, but several values (storno, correction, etc.) are
@@ -82,6 +83,22 @@ export function VoucherSeriesPerSourceTypeForm({ settings, onSettingsUpdated }: 
   const [isSaving, setIsSaving] = useState(false)
   const [showAll, setShowAll] = useState(false)
 
+  // Same closed list as the manual verifikat form and the per-bankkonto
+  // picker: the fixed Swedish presets, then any letter the company already
+  // uses that the presets do not cover, so no saved value falls out of the
+  // list. A free A-Z list would let a typo start an undocumented series.
+  const seriesOptions = useMemo(() => {
+    const preset = new Set(VOUCHER_SERIES_PRESETS.map((p) => p.letter))
+    const extras = [settings.default_voucher_series, ...Object.values(draft)].filter(
+      (v): v is string => typeof v === 'string' && SERIES_LETTER_RE.test(v) && !preset.has(v),
+    )
+    const uniqueExtras = Array.from(new Set(extras)).sort()
+    return [
+      ...VOUCHER_SERIES_PRESETS,
+      ...uniqueExtras.map((letter) => ({ letter, label: '' })),
+    ]
+  }, [settings.default_voucher_series, draft])
+
   const handleChange = (sourceType: JournalEntrySourceType, value: string) => {
     setDraft((prev) => ({ ...prev, [sourceType]: value }))
   }
@@ -142,9 +159,9 @@ export function VoucherSeriesPerSourceTypeForm({ settings, onSettingsUpdated }: 
         onChange={(e) => handleChange(key, e.target.value)}
         className="font-mono"
       >
-        {SERIES_OPTIONS.map((letter) => (
-          <option key={letter} value={letter}>
-            {letter}
+        {seriesOptions.map((option) => (
+          <option key={option.letter} value={option.letter}>
+            {option.label ? `${option.letter}  ${option.label}` : option.letter}
           </option>
         ))}
       </SettingsSelect>
@@ -157,7 +174,7 @@ export function VoucherSeriesPerSourceTypeForm({ settings, onSettingsUpdated }: 
   return (
     <SettingsGroup
       label="Verifikationsserier per typ"
-      help="Tilldela en standardserie per typ av verifikat. Vanlig svensk praxis: leverantörsfakturor på serie B, löner på serie C, övrigt på serie A. Kan alltid ändras per verifikat när du bokför."
+      help="Tilldela en standardserie per typ av verifikat. Vanlig svensk praxis: kundfakturor på serie B, leverantörsfakturor på serie D, löner på serie K, övrigt på serie A. Kan alltid ändras per verifikat när du bokför."
     >
       {alwaysVisible.map((entry, i) =>
         // The last always-visible row sits right above the fold toggle:


### PR DESCRIPTION
# What and why

The "Verifikationsserier per typ" selects in settings offered bare letters A to Z, while the manual verifikat dialog and the per-bankkonto picker already show the letter with its Swedish name (A Redovisning, B Kundfakturor, ...). A byrå partner asked for the names in that dropdown on 2026-09-03.

- Use the shared `VOUCHER_SERIES_PRESETS` list in `VoucherSeriesPerSourceTypeForm`, plus any letter already configured (global default, saved per-type map, current draft) so no stored value drops out of the select.
- Render options as `A  Redovisning`, bare letter for non-preset extras. Same shape as the per-bankkonto select.
- Rewrite the group's help text: it said leverantörsfakturor on B and löner on C, which contradicted the preset names. It now names the Fortnox convention explicitly and says the letter is a free choice, since the SIE-world convention (F/L/N) differs.

No migration. Stored value is still the single letter. UI-only change, no new i18n strings (labels are bookkeeping-domain Swedish terms that stay Swedish in both locales).

## Fix from first principles

1. **Why it occurred**: the series names live in one constant (`VOUCHER_SERIES_PRESETS`) but this form predates it and kept its own hardcoded `'A'..'Z'` list, so it never picked up the names. Three pickers, two option sources.
2. **What was removed**: the form's private A-Z list. It now reads the shared preset list like the other two pickers, so the names cannot drift again.
3. **Alternative considered**: keep all 26 letters and only decorate the 13 presets. Rejected for consistency with the manual verifikat picker, which already went closed-list (a typo'd letter silently starts a new number sequence). A letter outside the presets remains reachable via the global "Standardserie" select, which still offers A to Z. Persisting per-company series names would be the full answer to the reporter's wider ask (only some series open for manual entry) and is left for that feature.

## Review dispositions

- Skeptic (regression): a saved non-preset letter vanished from the list when its row was changed. Fixed in e05c895de by seeding extras from the saved map.
- CodeRabbit: same concern for values arriving after mount. Fixed by the same change. The wider "sync draft with later settings" ask is pre-existing behaviour of this form and out of scope.
- Swedish review: help text claimed "vanlig svensk praxis". Fixed, now names the Fortnox convention. Note on shared counters per series: pre-existing, `voucher_sequences` is keyed per series letter, not per source type.
- CodeRabbit docstring-coverage warning: declined, the repo does not enforce it.

## Checklist

- [x] Title follows Conventional Commits
- [x] `npm run check:lint`, `npm run check:guards`, and the resolver tests pass locally
- [x] No new `lib/` or `app/api/` logic (client component only)
- [x] No new UI strings
- [x] No migrations
- [x] No `@/extensions/` imports
- [ ] Commits are signed off

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017othUwkVfteSUf5q1CxPeC
