### PR TITLE
fix(expenses): review follow-ups from #2317

### DIFF
--- a/components/extensions/general/InvoiceInboxWorkspace.tsx
+++ b/components/extensions/general/InvoiceInboxWorkspace.tsx
@@ -3,6 +3,7 @@
 import { useState, useCallback, useEffect, useRef, useMemo } from 'react'
 import { useCompanySettings } from '@/lib/reference-data/hooks'
 import { useTranslations } from 'next-intl'
+import { useRouter } from 'next/navigation'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
@@ -495,6 +496,9 @@ export default function InvoiceInboxWorkspace(_props: WorkspaceComponentProps) {
   const [bookDirectOpen, setBookDirectOpen] = useState(false)
   // "Vem betalade?" answered with a person: the utlägg confirm step.
   const [registerExpensePayer, setRegisterExpensePayer] = useState<ExpensePayer | null>(null)
+  // The layout computes the Utlägg nav gate (hasExpenseClaims) on the server;
+  // the first booked claim must re-run it or the row stays hidden until reload.
+  const router = useRouter()
   // Bulk-book selected underlag (Modell B): the "Bokför valda" selection-bar
   // action. The dialog filters the selection to bookable items itself.
   const [bulkBookOpen, setBulkBookOpen] = useState(false)
@@ -2244,6 +2248,7 @@ export default function InvoiceInboxWorkspace(_props: WorkspaceComponentProps) {
         payer={registerExpensePayer}
         onSuccess={async () => {
           await Promise.all([fetchItems(), handleSelect(selected.id)])
+          router.refresh()
         }}
       />
     )}

--- a/components/extensions/general/RegisterExpenseDialog.tsx
+++ b/components/extensions/general/RegisterExpenseDialog.tsx
@@ -62,7 +62,12 @@ interface Props {
 const OWNER_FALLBACK_NAME = 'Ägare'
 
 function todayIso(): string {
-  return new Date().toISOString().slice(0, 10)
+  // Local calendar date: toISOString() is UTC and would date a receipt booked
+  // after midnight CEST to the previous day (wrong period, wrong FX rate).
+  const now = new Date()
+  const mm = String(now.getMonth() + 1).padStart(2, '0')
+  const dd = String(now.getDate()).padStart(2, '0')
+  return `${now.getFullYear()}-${mm}-${dd}`
 }
 
 function parseAmount(raw: string): number {

--- a/extensions/general/mcp-server/resources/attention.ts
+++ b/extensions/general/mcp-server/resources/attention.ts
@@ -439,7 +439,7 @@ export const attentionResource: McpResource = {
         })),
         next: {
           description:
-            'Betala ut från företagskontot och bokför utbetalningen (2893/2820 D mot 19xx K) via /expenses eller POST /api/expense-claims/payouts.',
+            'Betala ut från företagskontot och bokför utbetalningen: debitera radens liability_account (2893 ägare i AB, 2018 ägare i enskild firma, 2820 anställd) mot 19xx K, via /expenses eller POST /api/expense-claims/payouts.',
         },
       })
     }

--- a/lib/worklist/categories.ts
+++ b/lib/worklist/categories.ts
@@ -12,6 +12,7 @@ import { OPEN_ROT_RUT_PAYOUT_STATUSES } from '@/lib/invoices/rot-rut-payout-matc
 import type { SupabaseClient } from '@supabase/supabase-js'
 import { createLogger } from '@/lib/logger'
 import { roundOre } from '@/lib/money'
+import { fetchAllRows } from '@/lib/supabase/fetch-all'
 import {
   MATCHABLE_INVOICE_STATUSES,
   MATCHABLE_SUPPLIER_INVOICE_STATUSES,
@@ -565,13 +566,6 @@ export async function countReconciliationDue(
 }
 
 /**
- * Upper bound on registered-claim rows scanned per company. Claims are
- * marked paid in batches, so a backlog beyond this is pathological; the
- * list clamps rather than paginating on every home render.
- */
-export const EXPENSE_PAYOUT_SCAN_CAP = 500
-
-/**
  * People owed for registered, unpaid utlägg, newest debt last. The canonical
  * "att betala ut" predicate: expense_claims.status = 'registered'. Grouped
  * here (not in SQL) because the owner has no employee row: two owner claims
@@ -581,25 +575,34 @@ export async function listExpensePayoutsDue(
   supabase: SupabaseClient,
   companyId: string,
 ): Promise<ExpensePayoutDue[]> {
-  const { data, error } = await supabase
-    .from('expense_claims')
-    .select('employee_id, claimant_name, liability_account, amount_sek, expense_date')
-    .eq('company_id', companyId)
-    .eq('status', 'registered')
-    .order('expense_date', { ascending: true })
-    .limit(EXPENSE_PAYOUT_SCAN_CAP)
-  if (error) {
-    logAndZero('expense_payout', companyId, error)
-    return []
-  }
-  const byPerson = new Map<string, ExpensePayoutDue>()
-  for (const row of (data ?? []) as Array<{
+  type ClaimRow = {
+    id?: string
     employee_id: string | null
     claimant_name: string
     liability_account: string
     amount_sek: number | string
     expense_date: string
-  }>) {
+  }
+  let rows: ClaimRow[]
+  try {
+    // Every registered claim, paginated past the PostgREST row cap: a person
+    // omitted or a total understated here is money the company owes someone.
+    rows = await fetchAllRows<ClaimRow>(({ from, to }) =>
+      supabase
+        .from('expense_claims')
+        .select('id, employee_id, claimant_name, liability_account, amount_sek, expense_date')
+        .eq('company_id', companyId)
+        .eq('status', 'registered')
+        .order('expense_date', { ascending: true })
+        .order('id', { ascending: true })
+        .range(from, to),
+    )
+  } catch (err) {
+    logAndZero('expense_payout', companyId, err as { message?: string })
+    return []
+  }
+  const byPerson = new Map<string, ExpensePayoutDue>()
+  for (const row of rows) {
     const key = row.employee_id ?? `owner:${row.claimant_name}`
     const amount = Number(row.amount_sek) || 0
     const existing = byPerson.get(key)


### PR DESCRIPTION
The four CodeRabbit findings on #2317, all valid, all applied:

- **Stale nav gate**: `hasExpenseClaims` is computed in the dashboard layout on the server. After the first claim books from the Underlag pane, `router.refresh()` re-runs it so the Utlägg row appears without a reload.
- **UTC date**: `todayIso()` used `toISOString()`, which dates a receipt booked between 00:00 and 01:59 CEST to the previous day (wrong period, wrong FX rate). Now built from local date fields.
- **500-row cap**: `listExpensePayoutsDue` paged nothing past 500 registered claims, so a person could be omitted or a total understated on Hem and in the attention resource. Now `fetchAllRows` over `expense_claims` ordered by `expense_date, id`.
- **2018 missing**: the attention resource told agents to debit 2893/2820 on payout; an enskild firma owner sits on 2018. The instruction now points at each row's `liability_account`.

## First principles

1. Why: the first PR computed a nav flag server-side without a client refresh path, used the common UTC-date shortcut, and capped a money aggregation for cheapness.
2. Removed: the `EXPENSE_PAYOUT_SCAN_CAP` constant.
3. Why this over alternatives: a DB-side aggregate would need a migration for one query; `fetchAllRows` is the repo's standard for the PostgREST cap and keeps the owner grouping (`claimant_name`) in one place.

Checks: worklist, dashboard, expenses, MCP suites green (123 files); type/lint/antipattern ratchets clean. No migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P8YsvPqjfGxGZUkGeBVUWQ