### PR TITLE
fix(expenses): no help line for "Företaget" in the Vem betalade select

### DIFF
--- a/components/extensions/general/InvoiceInboxWorkspace.tsx
+++ b/components/extensions/general/InvoiceInboxWorkspace.tsx
@@ -3100,8 +3100,16 @@ export function PayerChoiceSelect({
   accountingMethod: AccountingMethod
 }) {
   const t = useTranslations('inbox_workspace')
-  const helpKey = (choice: PayerChoice): string =>
-    choice === 'unpaid' && accountingMethod === 'cash' ? 'payer_help_unpaid_cash' : `payer_help_${choice}`
+  // Företaget carries no help line: the button under it ("Matcha mot
+  // transaktion") already says what happens. The other answers name the
+  // liability the company takes on, which is the consequence worth reading.
+  const helpKey = (choice: PayerChoice): string | null =>
+    choice === 'company'
+      ? null
+      : choice === 'unpaid' && accountingMethod === 'cash'
+        ? 'payer_help_unpaid_cash'
+        : `payer_help_${choice}`
+  const selectedHelp = helpKey(value)
   return (
     <div className="space-y-1.5">
       <p className="text-[13px] font-medium">{t('payer_question')}</p>
@@ -3117,12 +3125,14 @@ export function PayerChoiceSelect({
           {PAYER_ORDER.map((choice) => (
             <SelectItem key={choice} value={choice} className="py-2">
               <span className="block text-[13px]">{t(`payer_${choice}`)}</span>
-              <span className="block text-xs text-muted-foreground">{t(helpKey(choice))}</span>
+              {helpKey(choice) && (
+                <span className="block text-xs text-muted-foreground">{t(helpKey(choice)!)}</span>
+              )}
             </SelectItem>
           ))}
         </SelectContent>
       </Select>
-      <p className="text-xs text-muted-foreground">{t(helpKey(value))}</p>
+      {selectedHelp && <p className="text-xs text-muted-foreground">{t(selectedHelp)}</p>}
     </div>
   )
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -3304,7 +3304,6 @@
   "inbox_workspace": {
     "payer_question": "Who paid?",
     "payer_company": "The company",
-    "payer_help_company": "Card or bank account. Matched against the transaction when it appears.",
     "payer_owner": "Me, privately",
     "payer_help_owner": "The company owes you the amount. Paid out from the company account later.",
     "payer_employee": "An employee",

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -3304,7 +3304,6 @@
   "inbox_workspace": {
     "payer_question": "Vem betalade?",
     "payer_company": "Företaget",
-    "payer_help_company": "Kort eller bankkonto. Matchas mot transaktionen när den syns.",
     "payer_owner": "Jag, privat",
     "payer_help_owner": "Bolaget blir skyldigt dig beloppet. Betalas ut från företagskontot senare.",
     "payer_employee": "En anställd",


### PR DESCRIPTION
Founder feedback on #2327 live: drop "Kort eller bankkonto. Matchas mot transaktionen när den syns."

- The Företaget answer renders without a help line, both under the trigger and in the option list; the primary button under it already says what happens.
- Jag, privat / En anställd / Ingen ännu keep their line, which names the liability the company takes on.
- `payer_help_company` removed from `messages/sv.json` and `messages/en.json`; no remaining references.

Lint and the type/lint ratchets are clean. No migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P8YsvPqjfGxGZUkGeBVUWQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Removed the explanatory help text for the “The company” payer option in the invoice inbox.
  * Help text remains available for payer options that include relevant guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->