### PR TITLE
fix(invoices): scope-check article ids in buildInvoiceWriteData so every invoice write refuses a foreign company's article (part of #2059)

### DIFF
--- a/app/api/invoices/[id]/__tests__/route.test.ts
+++ b/app/api/invoices/[id]/__tests__/route.test.ts
@@ -4,10 +4,11 @@ import {
   createMockRouteParams,
   parseJsonResponse,
   createQueuedMockSupabase,
+  makeCustomer,
 } from '@/tests/helpers'
 import { eventBus } from '@/lib/events'
 
-const { supabase: mockSupabase, enqueue, reset } = createQueuedMockSupabase()
+const { supabase: mockSupabase, enqueue, reset, findCall } = createQueuedMockSupabase()
 vi.mock('@/lib/supabase/server', () => ({
   createClient: () => Promise.resolve(mockSupabase),
 }))
@@ -224,5 +225,60 @@ describe('PATCH /api/invoices/[id]', () => {
 
     expect(status).toBe(409)
     expect(body.error.code).toBe('INVOICE_UPDATE_NOT_DRAFT')
+  })
+
+  it('refuses an article id that belongs to another company before writing anything (issue #2059)', async () => {
+    // The FK on invoice_items.article_id proves the article exists, not that
+    // it is this company's; the cookie route relies on the builder's scoped
+    // select for that (RLS never sees FK validation).
+    const FOREIGN_ARTICLE = 'ffffffff-ffff-4fff-8fff-ffffffffffff'
+    enqueue({
+      data: {
+        id: 'inv-1',
+        status: 'draft',
+        invoice_number: null,
+        journal_entry_id: null,
+        is_self_billed: false,
+        credited_invoice_id: null,
+        document_type: 'invoice',
+        quote_status: null,
+        deduction_personnummer_encrypted: null,
+        deduction_personnummer_last4: null,
+      },
+      error: null,
+    }) // invoices: the draft being edited
+    enqueue({ data: makeCustomer({ id: '22222222-2222-4222-8222-222222222222', customer_type: 'swedish_business' }), error: null }) // customers
+    enqueue({ data: { vat_registered: true }, error: null }) // company_settings (builder VAT gate)
+    enqueue({ data: [], error: null }) // articles: no company-scoped hit
+
+    const response = await PATCH(
+      createMockRequest('/api/invoices/inv-1', {
+        method: 'PATCH',
+        body: {
+          customer_id: '22222222-2222-4222-8222-222222222222',
+          invoice_date: '2026-07-14',
+          due_date: '2026-08-13',
+          currency: 'SEK',
+          items: [
+            {
+              description: 'Konsult',
+              quantity: 1,
+              unit: 'tim',
+              unit_price: 1000,
+              vat_rate: 25,
+              article_id: FOREIGN_ARTICLE,
+            },
+          ],
+        },
+      }),
+      createMockRouteParams({ id: 'inv-1' }),
+    )
+    const { status, body } = await parseJsonResponse<{ error: { code: string; details?: { invalidArticleIds?: string[] } } }>(response)
+
+    expect(status).toBe(400)
+    expect(body.error.code).toBe('INVOICE_CREATE_ARTICLE_INVALID')
+    expect(findCall('articles', 'eq')).toEqual(['company_id', 'company-1'])
+    expect(findCall('invoices', 'update')).toBeUndefined()
+    expect(findCall('invoice_items', 'insert')).toBeUndefined()
   })
 })

--- a/app/api/v1/companies/[companyId]/invoices/__tests__/route.test.ts
+++ b/app/api/v1/companies/[companyId]/invoices/__tests__/route.test.ts
@@ -957,9 +957,11 @@ describe('POST /api/v1/companies/:companyId/invoices', () => {
                     ? SWEDISH_BUSINESS_CUSTOMER
                     : table === 'chart_of_accounts'
                       ? [{ account_number: '3041' }]
-                      : table === 'invoices'
-                        ? createdInvoice
-                        : null
+                      : table === 'articles'
+                        ? [{ id: ARTICLE_ID }]
+                        : table === 'invoices'
+                          ? createdInvoice
+                          : null
               return (r: (v: unknown) => void) => r({ data, error: null })
             }
             return () => new Proxy({}, handler)
@@ -1099,6 +1101,39 @@ describe('POST /api/v1/companies/:companyId/invoices', () => {
     expect(res.status).toBe(400)
     const body = await res.json()
     expect(body.error.code).toBe('INVOICE_CREATE_REVENUE_ACCOUNT_INVALID')
+  })
+
+  it('rejects an article_id that belongs to another company (issue #2059)', async () => {
+    // v1 runs on the service-role client with no RLS: the FK on
+    // invoice_items.article_id proves existence only, so the scoped select in
+    // the builder is the only tenancy guard for article linkage.
+    withInvoiceWriteScope()
+    const FOREIGN_ARTICLE = 'ffffffff-ffff-4fff-8fff-ffffffffffff'
+    mockServiceClient.mockReturnValue(
+      makeFlexibleSupabase({
+        company_members: { data: { company_id: COMPANY_ID, role: 'owner' }, error: null },
+        customers: { data: SWEDISH_BUSINESS_CUSTOMER, error: null },
+        articles: { data: [], error: null },
+      }),
+    )
+
+    const res = await createInvoice(
+      makePostInvoice(`https://x.test/api/v1/companies/${COMPANY_ID}/invoices`, {
+        customer_id: CUSTOMER_ID,
+        invoice_date: '2026-05-12',
+        due_date: '2026-06-11',
+        currency: 'SEK',
+        items: [
+          { description: 'x', quantity: 1, unit: 'st', unit_price: 100, article_id: FOREIGN_ARTICLE },
+        ],
+      }),
+      companyParams(COMPANY_ID),
+    )
+
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.error.code).toBe('INVOICE_CREATE_ARTICLE_INVALID')
+    expect(body.error.details).toEqual({ invalidArticleIds: [FOREIGN_ARTICLE] })
   })
 })
 

--- a/lib/errors/structured-errors.ts
+++ b/lib/errors/structured-errors.ts
@@ -888,6 +888,11 @@ const INVOICE: Record<string, StructuredErrorEntry> = {
     message_sv: 'Ett angivet bokföringskonto finns inte eller är inte ett aktivt balans- eller intäktskonto (klass 1-3).',
     message_en: 'A supplied posting account does not exist or is not an active balance-sheet or revenue account (class 1-3).',
   },
+  INVOICE_CREATE_ARTICLE_INVALID: {
+    httpStatus: 400,
+    message_sv: 'En angiven artikel finns inte i företaget.',
+    message_en: 'A supplied article does not exist in this company.',
+  },
   INVOICE_CREATE_POSTING_ACCOUNT_VAT_CONFLICT: {
     httpStatus: 400,
     message_sv: 'Ett balanskonto (klass 1-2) kan bara användas på rader utan moms. Använd ett intäktskonto (3xxx) för momspliktiga rader.',

--- a/lib/invoices/__tests__/build-invoice-write.test.ts
+++ b/lib/invoices/__tests__/build-invoice-write.test.ts
@@ -597,3 +597,85 @@ describe('buildInvoiceWriteData kundkort fallback customer-type gate', () => {
     expect(result.items[0]).toMatchObject({ sales_order_item_id: null })
   })
 })
+
+describe('buildInvoiceWriteData article company scope (issue #2059)', () => {
+  const ARTICLE_A = 'a1000000-0000-4000-8000-000000000001'
+  const ARTICLE_B = 'a1000000-0000-4000-8000-000000000002'
+  const FOREIGN_ARTICLE = 'a1000000-0000-4000-8000-0000000000ff'
+  const customer = makeCustomer({ customer_type: 'swedish_business' })
+
+  it('refuses an article id the company-scoped select cannot see', async () => {
+    const { supabase, enqueue, findCall } = createQueuedMockSupabase()
+    enqueue({ data: { vat_registered: true }, error: null }) // company_settings
+    enqueue({ data: [], error: null }) // articles: no company-scoped hit
+
+    const result = await call(enqueue, supabase as unknown as SupabaseClient, customer, {
+      ...baseHeader,
+      items: [
+        { description: 'Konsult', quantity: 1, unit: 'tim', unit_price: 1000, vat_rate: 25, article_id: FOREIGN_ARTICLE },
+      ],
+    })
+
+    expect(result.ok).toBe(false)
+    if (result.ok || !('code' in result)) return
+    expect(result.code).toBe('INVOICE_CREATE_ARTICLE_INVALID')
+    expect(result.details).toEqual({ invalidArticleIds: [FOREIGN_ARTICLE] })
+    // The select is scoped on company_id: the FK alone only proves existence.
+    expect(findCall('articles', 'eq')).toEqual(['company_id', 'company-1'])
+    expect(findCall('articles', 'in')).toEqual(['id', [FOREIGN_ARTICLE]])
+  })
+
+  it('accepts company-owned articles, deduping repeated ids into one select', async () => {
+    const { supabase, enqueue, findCall } = createQueuedMockSupabase()
+    enqueue({ data: { vat_registered: true }, error: null }) // company_settings
+    enqueue({ data: [{ id: ARTICLE_A }, { id: ARTICLE_B }], error: null }) // articles
+
+    const result = await call(enqueue, supabase as unknown as SupabaseClient, customer, {
+      ...baseHeader,
+      items: [
+        { description: 'Rad 1', quantity: 1, unit: 'st', unit_price: 100, vat_rate: 25, article_id: ARTICLE_A },
+        { description: 'Rad 2', quantity: 2, unit: 'st', unit_price: 100, vat_rate: 25, article_id: ARTICLE_A },
+        { description: 'Rad 3', quantity: 1, unit: 'st', unit_price: 100, vat_rate: 25, article_id: ARTICLE_B },
+      ],
+    })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.items.map((i) => i.article_id)).toEqual([ARTICLE_A, ARTICLE_A, ARTICLE_B])
+    expect(findCall('articles', 'in')).toEqual(['id', [ARTICLE_A, ARTICLE_B]])
+  })
+
+  it('never queries articles when no product line carries an article id', async () => {
+    const { supabase, enqueue } = createQueuedMockSupabase()
+    enqueue({ data: { vat_registered: true }, error: null }) // company_settings
+
+    const result = await call(enqueue, supabase as unknown as SupabaseClient, customer, {
+      ...baseHeader,
+      items: [
+        { description: 'Konsult', quantity: 1, unit: 'tim', unit_price: 1000, vat_rate: 25 },
+        // A text row never persists an article, so an id on it must not be checked.
+        { line_type: 'text', description: 'Fri text', quantity: 0, unit: '', unit_price: 0, article_id: FOREIGN_ARTICLE },
+      ],
+    })
+
+    expect(result.ok).toBe(true)
+    expect(supabase.from).not.toHaveBeenCalledWith('articles')
+  })
+
+  it('surfaces a DB error on the article lookup as dbError, not as a refusal', async () => {
+    const { supabase, enqueue } = createQueuedMockSupabase()
+    enqueue({ data: { vat_registered: true }, error: null }) // company_settings
+    enqueue({ data: null, error: { message: 'connection reset' } }) // articles
+
+    const result = await call(enqueue, supabase as unknown as SupabaseClient, customer, {
+      ...baseHeader,
+      items: [
+        { description: 'Konsult', quantity: 1, unit: 'tim', unit_price: 1000, vat_rate: 25, article_id: ARTICLE_A },
+      ],
+    })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect('dbError' in result).toBe(true)
+  })
+})

--- a/lib/invoices/build-invoice-write.ts
+++ b/lib/invoices/build-invoice-write.ts
@@ -318,6 +318,40 @@ export async function buildInvoiceWriteData(params: {
     }
   }
 
+  // Article linkage is a tenancy invariant: the FK on invoice_items.article_id
+  // proves the article EXISTS, not that it belongs to THIS company. FK
+  // validation is internal to Postgres and ignores RLS, and the v1 routes run
+  // on the service-role client with no RLS at all, so a body carrying another
+  // company's article UUID would otherwise persist a cross-tenant reference.
+  // Every invoice write path converges here (cookie POST/PATCH, v1 POST/PATCH,
+  // webshop, sales-order conversion, MCP update), so one scoped select covers
+  // them all. The MCP executors keep their own pre-check as the tamper gate
+  // for staged rows. Text rows never persist an article (mapped to null below).
+  const articleIds = Array.from(
+    new Set(
+      items
+        .filter((item) => item.line_type !== 'text')
+        .map((item) => item.article_id)
+        .filter((a): a is string => !!a),
+    ),
+  )
+  if (articleIds.length > 0) {
+    const { data: articleRows, error: articlesError } = await supabase
+      .from('articles')
+      .select('id')
+      .eq('company_id', companyId)
+      .in('id', articleIds)
+
+    if (articlesError) {
+      return { ok: false, dbError: articlesError }
+    }
+    const foundArticleIds = new Set((articleRows ?? []).map((a) => a.id))
+    const invalidArticleIds = articleIds.filter((a) => !foundArticleIds.has(a))
+    if (invalidArticleIds.length > 0) {
+      return { ok: false, code: 'INVOICE_CREATE_ARTICLE_INVALID', details: { invalidArticleIds } }
+    }
+  }
+
   // ROT/RUT-avdrag: validate prerequisites and compute the per-item +
   // invoice-level deduction. Computed server-side (never trusted from the
   // client) so a tampered request can't expand the 1513 receivable. Skipped

--- a/lib/pending-operations/__tests__/update-invoice-executor.test.ts
+++ b/lib/pending-operations/__tests__/update-invoice-executor.test.ts
@@ -260,6 +260,7 @@ describe('commitPendingOperation: update_invoice', () => {
     enqueue({ data: [{ id: ARTICLE_ID }] }) // articles: company-scope gate
     enqueue({ data: { vat_registered: true } }) // company_settings (builder VAT gate)
     enqueue({ data: [{ account_number: '3041' }] }) // chart_of_accounts: override account
+    enqueue({ data: [{ id: ARTICLE_ID }] }) // articles: builder company-scope check (#2059)
     enqueue({ data: [{ id: INVOICE_ID }] }) // invoices update (draft-guarded)
     enqueue({ data: [] }) // invoice_items snapshot (replaceInvoiceItems)
     enqueue({ data: null }) // invoice_items delete


### PR DESCRIPTION
Part of #2059 (Part 2 only: the article company-scope hardening bug). Part 1 (ROT/RUT and accrual lines on MCP `create_invoice`) is deliberately NOT in this PR; see "For the founder".

## What

`buildInvoiceWriteData` (`lib/invoices/build-invoice-write.ts`) now scope-checks every `items[].article_id` against the writing company: it collects the distinct article ids from product lines, runs one `articles` select filtered on `company_id`, and refuses with the new structured code `INVOICE_CREATE_ARTICLE_INVALID` (400, `details.invalidArticleIds`) on any miss. A lookup failure surfaces as `dbError` like the sibling `chart_of_accounts` check.

That one check now covers every writer that goes through the builder: cookie POST `/api/invoices`, cookie PATCH `/api/invoices/[id]`, v1 POST and PATCH under `/api/v1/companies/[companyId]/invoices`, the webshop create-invoice route, the sales-order conversion (`lib/sales-orders/create-invoice-from-order.ts`) and the MCP `commitUpdateInvoice` executor. The routes need no edits: they already map `build.code` through `errorResponseFromCode`, so the registry row alone gives the status and the Swedish message (`lib/errors/get-error-message.ts` resolves through the same registry).

The MCP executor checks in `lib/pending-operations/commit.ts` are kept unchanged: `commitCreateInvoice` does not go through the builder, and for staged rows both are the tamper gate that runs before any write. On the MCP update path this means one extra scoped select when a staged line carries an article; the builder's is the invariant, the executor's is the gate.

## First principles

1. **Why did it occur?** The invariant "an invoice line may only reference the company's own article" lived in application code in two of seven write paths. The FK on `invoice_items.article_id` proves the article exists, not whose it is: FK validation is internal to Postgres and ignores RLS, and the v1 routes run on the service-role client (`lib/api/v1/with-api-v1.ts`) with no RLS at all, so a crafted body carrying a foreign article UUID persisted a cross-tenant reference. Each write path that grew after the MCP executors were hardened (#1993) had to remember the check on its own, and none did. The class-level fix is one check at the point all paths converge, which is why it sits in the builder next to the `chart_of_accounts` scope check that already does the same job for `revenue_account`.

2. **What could be removed or simplified?** Nothing was added to any route; zero route edits. The check reuses the builder's existing result shape (`code` / `details` / `dbError`) and the existing registry-driven error mapping, so no new error plumbing, no new i18n keys, no new states. The `commitUpdateInvoice` executor's own check could in principle be dropped now that the builder covers it, but the assignment keeps it as the staged-row tamper gate, and it is the same shape as the `commitCreateInvoice` check that the builder cannot cover until Part 1 rebases create onto the builder. The moment Part 1 lands, both executor checks become removable in one sweep.

3. **Is this the best solution?** For the immediate fix, yes: the issue's proposal and the builder-level check coincide. I evaluated pushing the invariant below application code entirely, into the database (option B), and did not ship it:
   - A composite FK `invoice_items (article_id, company_id) -> articles (id, company_id)` needs a `company_id` column on `invoice_items`, which does not exist (the table is scoped through `invoices`; the RLS policies in `20260702093000` join `invoices.company_id`), plus a `UNIQUE (id, company_id)` on `articles` (only the `id` PK and `uq_articles_company_number` exist). So it means a denormalized column, a prod backfill from `invoices`, a sync trigger to keep it correct, and the FK added `NOT VALID` then `VALIDATE`d. That is a larger schema change than the bug.
   - A lighter DB variant is a constraint trigger on `invoice_items` (`BEFORE INSERT OR UPDATE OF article_id`) that joins `invoices.company_id` to `articles.company_id` and raises. No new column, but triggers cannot be validated against existing rows the way `NOT VALID` FKs can, and I cannot query prod from this session to confirm no row already violates it.
   Either DB path is the right long-term home (it would hold for every future writer, including service-role scripts, with no application code), so it is listed as option B for the founder below with the prod check query. Shipping a migration that could fail on data I cannot see would be worse than the application-level fix.

## Verification

Run from the worktree at `135a6150a`:

```
npx vitest run --project unit lib/invoices lib/errors lib/pending-operations lib/sales-orders "app/api/invoices" "app/api/v1/companies/[companyId]/invoices" app/api/webshop-orders
 Test Files  182 passed (182)
      Tests  2839 passed (2839)

npx vitest run --project unit --reporter=verbose (new cases)
 ✓ build-invoice-write.test.ts > article company scope (issue #2059) > refuses an article id the company-scoped select cannot see
 ✓ build-invoice-write.test.ts > article company scope (issue #2059) > accepts company-owned articles, deduping repeated ids into one select
 ✓ build-invoice-write.test.ts > article company scope (issue #2059) > never queries articles when no product line carries an article id
 ✓ build-invoice-write.test.ts > article company scope (issue #2059) > surfaces a DB error on the article lookup as dbError, not as a refusal
 ✓ app/api/invoices/[id]/__tests__/route.test.ts > PATCH > refuses an article id that belongs to another company before writing anything (issue #2059)
 ✓ app/api/v1/.../invoices/__tests__/route.test.ts > POST > rejects an article_id that belongs to another company (issue #2059)
 ✓ app/api/v1/.../invoices/__tests__/route.test.ts > POST > persists article_id + revenue_account on line items (now answers the scoped select)
 ✓ lib/pending-operations/__tests__/update-invoice-executor.test.ts > keeps article_id and revenue_account on replaced items (issue #1642)

npm run check:lint
no-new-lint-errors: OK: 0 error(s), baseline 0.

npm run check:guards
✓ Antipattern guard passed (raw-route-auth: 1, ... direct-invoice-payment-insert: 0, leaky-supabase-client: 0, ... cross-extension-import: 0, ...)

node scripts/checks/no-new-type-errors.mjs
  extensions/general/email/lib/smtp-service.ts: 1 (baseline 0)   <- environmental: nodemailer types missing in the shared node_modules (documented in the batch brief); no other file trips

grep -r "from '@/extensions/" lib/ app/api/ components/ ... (core-imports-extensions scan)
(no output)
```

No migration. No i18n keys (the message lives in the structured-error registry, both languages). No API schema change (`article_id` was already a declared, UUID-validated field on `CreateInvoiceSchema` / `UpdateInvoiceSchema`), so `apiskill:generate` output is unchanged.

## For the founder

1. **Part 1 of #2059 (ROT/RUT and accrual lines on MCP `gnubok_create_invoice`) is NOT in this PR and needs your call on the MCP payload budget.** `payload-size.bench.test.ts` asserts the `tools/list` projection stays under 64 400 and it measures 64 315, so about 85 tokens of headroom remain; declaring the nine deduction/accrual fields with descriptions on the create item schema costs a few hundred. The bench ledger's standing rule is to demote a default-catalog read to search-only (viable since `gnubok_call_tool`) before proposing another ceiling bump, and choosing which read to demote wants prod usage data. Question from the issue: sequence a demotion, or bump the ceiling explicitly? Once decided, the recommended Part 1 route is to rebase `commitCreateInvoice` onto `buildInvoiceWriteData` (as `commitUpdateInvoice` already is), which makes this PR's scope check cover the MCP create path for free and lets both executor pre-checks be retired.

2. **Option B, DB-level enforcement (recommended follow-up, not shipped here).** The invariant would hold for every writer including future ones and service-role scripts if the database carried it. Two shapes, both need a prod pre-check first because this session could not query prod:
   ```sql
   -- must return 0 before either variant is applied
   select count(*)
   from invoice_items ii
   join invoices i on i.id = ii.invoice_id
   join articles a on a.id = ii.article_id
   where a.company_id <> i.company_id;
   ```
   - B1 (constraint trigger): `BEFORE INSERT OR UPDATE OF article_id ON invoice_items` that joins `invoices.company_id` to `articles.company_id` and raises. No new column, no backfill; ships with a `tests/pg/*.pg.test.ts`.
   - B2 (composite FK): add `invoice_items.company_id` (backfill from `invoices`, sync trigger), `UNIQUE (id, company_id)` on `articles`, then `FOREIGN KEY (article_id, company_id) REFERENCES articles (id, company_id) NOT VALID` followed by `VALIDATE CONSTRAINT`. Declarative and self-validating, but the denormalized column is a bigger surface than the bug.
   Recommendation: B1 as a small follow-up after Part 1 lands, keeping this PR's builder check as the application-level, typed-error surface (a raised trigger would arrive as a generic DB error at the route, not as `INVOICE_CREATE_ARTICLE_INVALID`).

3. Honest severity restated from the issue: low. `article_id` is a linkage column; `revenue_account` is frozen per line separately, so booking amounts were never affected. The damage was a persisted cross-tenant reference echoed on reads and polluted article linkage, and exploiting it required knowing a foreign article UUID. Defense-in-depth parity, not a data leak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019SaJfqNi4VmsG8FMKq99G6
