### PR TITLE
fix(import): show "created on import" as the mapping target for source accounts the chart lacks

### DIFF
--- a/components/extensions/general/ArcimMigrationWorkspace.tsx
+++ b/components/extensions/general/ArcimMigrationWorkspace.tsx
@@ -1490,6 +1490,7 @@ function openingBalanceSentence(ob: NonNullable<NonNullable<ImportResult['detail
  * errors keep strong color. Nothing folds away, nothing gets a box.
  */
 function FiscalYearLine({ result, index }: { result: ImportResult; index: number }) {
+  const t = useTranslations('extensions')
   const status = getFYStatus(result)
   const d = result.details
   const fyLabel = d?.fiscalYear
@@ -1503,7 +1504,16 @@ function FiscalYearLine({ result, index }: { result: ImportResult; index: number
     if (d.skippedVouchers.empty > 0) parts.push(`${d.skippedVouchers.empty} tomma`)
     if (d.skippedVouchers.unbalanced > 0) parts.push(`${d.skippedVouchers.unbalanced} obalanserade`)
     if (d.skippedVouchers.singleLine > 0) parts.push(`${d.skippedVouchers.singleLine} enradiga`)
-    if (d.skippedVouchers.unmapped > 0) parts.push(`${d.skippedVouchers.unmapped} med ej kopplade konton`)
+    if (d.skippedVouchers.unmapped > 0) {
+      // Name the accounts (issue #2212): a count alone sends the user to diff
+      // the general ledger against the source system by hand.
+      const perAccount = (d.skippedVouchers.unmappedAccounts ?? [])
+        .map((a) => `konto ${a.account}: ${a.vouchers}`)
+        .join(', ')
+      parts.push(
+        `${d.skippedVouchers.unmapped} med ej kopplade konton${perAccount ? ` (${perAccount})` : ''}`
+      )
+    }
     warningSentences.push(
       `${d.skippedVouchers.total} verifikationer hoppades över (${parts.join(', ')}): saldon har justerats automatiskt via omföringsverifikation.`
     )
@@ -1526,6 +1536,12 @@ function FiscalYearLine({ result, index }: { result: ImportResult; index: number
   )
 
   const infoLines: string[] = []
+  // Accounts the import inserted into the chart (self-mapped source accounts
+  // the company did not have). Said out loud so "did the import go right?"
+  // has an answer on screen instead of in a chart-of-accounts diff.
+  if (result.accountsCreated && result.accountsCreated > 0) {
+    infoLines.push(t('ext_arcim_accounts_created', { count: result.accountsCreated }))
+  }
   if (d?.openingBalance) infoLines.push(openingBalanceSentence(d.openingBalance))
   if (d?.migrationAdjustment?.created) {
     infoLines.push(

--- a/components/import/AccountMappingStep.tsx
+++ b/components/import/AccountMappingStep.tsx
@@ -31,6 +31,7 @@ import {
   Filter,
 } from 'lucide-react'
 import type { AccountMapping } from '@/lib/import/types'
+import { isValidBASRange } from '@/lib/import/account-mapper'
 import type { BASAccount } from '@/types'
 import { getAccountClassName } from '@/lib/bookkeeping/account-descriptions'
 import {
@@ -61,7 +62,7 @@ interface AccountMappingStepProps {
   onBack: () => void
 }
 
-type FilterType = 'all' | 'unmapped' | 'vat_review' | 'low_confidence' | 'manual'
+type FilterType = 'all' | 'unmapped' | 'new_account' | 'vat_review' | 'low_confidence' | 'manual'
 
 const PAGE_SIZE = 50
 
@@ -84,6 +85,19 @@ export default function AccountMappingStep({
   })
   const [currentPage, setCurrentPage] = useState(1)
 
+  // Targets the dropdown can name: the caller's list (the company chart, or
+  // chart + BAS). A mapped target outside it is an account the import will
+  // CREATE (syncMappedAccounts inserts every missing target, class and type
+  // derived from the number). Such a row is mapped and valid, but a Select
+  // whose value matches no option renders blank, which is how a self-mapped
+  // Fortnox account outside BAS looked unmapped and unmappable (issue #2212).
+  // Every target outside this set is therefore rendered as an explicit
+  // "created on import" option.
+  const knownTargets = useMemo(
+    () => new Set(basAccounts.map((a) => a.account_number)),
+    [basAccounts],
+  )
+
   // Filter and search mappings
   const filteredMappings = useMemo(() => {
     let result = mappings
@@ -92,6 +106,9 @@ export default function AccountMappingStep({
     switch (filter) {
       case 'unmapped':
         result = result.filter((m) => !m.targetAccount)
+        break
+      case 'new_account':
+        result = result.filter((m) => m.targetAccount && !knownTargets.has(m.targetAccount))
         break
       case 'low_confidence':
         result = result.filter((m) => m.targetAccount && m.confidence < 0.7)
@@ -117,7 +134,7 @@ export default function AccountMappingStep({
     }
 
     return result
-  }, [mappings, filter, searchTerm])
+  }, [mappings, filter, searchTerm, knownTargets])
 
   // Pagination
   const totalPages = Math.ceil(filteredMappings.length / PAGE_SIZE)
@@ -140,11 +157,20 @@ export default function AccountMappingStep({
   // Calculate stats
   const stats = useMemo(() => {
     const unmapped = mappings.filter((m) => !m.targetAccount).length
+    const newAccounts = mappings.filter((m) => m.targetAccount && !knownTargets.has(m.targetAccount)).length
     const lowConfidence = mappings.filter((m) => m.targetAccount && m.confidence < 0.7).length
     const manual = mappings.filter((m) => m.isOverride).length
     const vatReview = mappings.filter((m) => m.requiresVatTreatmentReview && !m.vatTreatmentReviewed).length
-    return { unmapped, lowConfidence, manual, vatReview }
-  }, [mappings])
+    return { unmapped, newAccounts, lowConfidence, manual, vatReview }
+  }, [mappings, knownTargets])
+
+  // After the mapper's self-map rule, an unmapped row is always a number
+  // outside 1000-8999: nothing can be created for it, so the user must pick a
+  // target. Name them so the disabled Continue button is not the only signal.
+  const unmappedAccounts = useMemo(
+    () => mappings.filter((m) => !m.targetAccount).map((m) => m.sourceAccount),
+    [mappings],
+  )
 
   const canContinue = stats.unmapped === 0 && stats.vatReview === 0
 
@@ -168,7 +194,8 @@ export default function AccountMappingStep({
           <CardTitle>Kontomappning</CardTitle>
           <CardDescription>
             Varje konto i SIE-filen kopplas till ett konto i din kontoplan.
-            De flesta matchas automatiskt: granska de osäkra nedan.
+            De flesta matchas automatiskt: granska de osäkra nedan.{' '}
+            {t('mapping_new_accounts_note')}
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
@@ -189,6 +216,14 @@ export default function AccountMappingStep({
             >
               <XCircle className="h-3 w-3 mr-1" />
               {stats.unmapped} ej mappade
+            </Badge>
+            <Badge
+              variant={filter === 'new_account' ? 'default' : stats.newAccounts > 0 ? 'secondary' : 'outline'}
+              className="cursor-pointer"
+              onClick={() => handleFilterChange('new_account')}
+            >
+              <CheckCircle className="h-3 w-3 mr-1" />
+              {t('new_account_filter', { count: stats.newAccounts })}
             </Badge>
             <Badge
               variant={filter === 'low_confidence' ? 'default' : stats.lowConfidence > 0 ? 'secondary' : 'outline'}
@@ -215,6 +250,12 @@ export default function AccountMappingStep({
             </Badge>
           </div>
 
+          {unmappedAccounts.length > 0 && (
+            <p className="text-sm text-muted-foreground">
+              {t('unmapped_out_of_range_help', { accounts: unmappedAccounts.join(', ') })}
+            </p>
+          )}
+
           {/* Search and filter */}
           <div className="flex gap-4">
             <div className="relative flex-1">
@@ -234,6 +275,7 @@ export default function AccountMappingStep({
               <SelectContent>
                 <SelectItem value="all">Visa alla</SelectItem>
                 <SelectItem value="unmapped">Ej mappade</SelectItem>
+                <SelectItem value="new_account">{t('new_account_filter', { count: stats.newAccounts })}</SelectItem>
                 <SelectItem value="vat_review">{t('vat_review_filter', { count: stats.vatReview })}</SelectItem>
                 <SelectItem value="low_confidence">Osäkra</SelectItem>
                 <SelectItem value="manual">Manuellt satta</SelectItem>
@@ -274,7 +316,11 @@ export default function AccountMappingStep({
                   >
                     <TableCell className="font-mono">{mapping.sourceAccount}</TableCell>
                     <TableCell className="text-muted-foreground">
-                      <TruncatedSourceName sourceName={mapping.sourceName} />
+                      {mapping.sourceName ? (
+                        <TruncatedSourceName sourceName={mapping.sourceName} />
+                      ) : (
+                        <span className="italic">{t('source_name_missing')}</span>
+                      )}
                     </TableCell>
                     <TableCell className="!px-0">
                       <ArrowRight className="mx-auto h-4 w-4 text-muted-foreground" />
@@ -284,10 +330,15 @@ export default function AccountMappingStep({
                         value={mapping.targetAccount || 'none'}
                         onValueChange={(value) => {
                           const account = basAccounts.find((a) => a.account_number === value)
+                          // A target outside the list is created on import
+                          // under the file's name (the identity option) or
+                          // the name the row already carries.
+                          const createdName =
+                            value === mapping.sourceAccount ? mapping.sourceName : mapping.targetName
                           onMappingChange(
                             mapping.sourceAccount,
                             value === 'none' ? '' : value,
-                            account?.account_name || ''
+                            account?.account_name ?? createdName ?? ''
                           )
                         }}
                       >
@@ -296,6 +347,15 @@ export default function AccountMappingStep({
                         </SelectTrigger>
                         <SelectContent className="max-h-80">
                           <SelectItem value="none">-- Välj konto --</SelectItem>
+                          {createdOptionsFor(mapping, knownTargets).map((option) => (
+                            <SelectItem key={option.value} value={option.value}>
+                              <span className="font-mono mr-2">{option.value}</span>
+                              {option.name}
+                              <span className="ml-2 text-muted-foreground">
+                                ({t('new_account_option')})
+                              </span>
+                            </SelectItem>
+                          ))}
                           {Object.entries(accountsByClass).map(([className, accounts]) => (
                             <div key={className}>
                               <div className="px-2 py-1.5 text-xs font-semibold text-muted-foreground bg-muted">
@@ -493,6 +553,37 @@ export default function AccountMappingStep({
       </div>
     </div>
   )
+}
+
+/**
+ * The "created on import" options a row can select: its own number (when
+ * that is in the auto-create range and not already in the chart) and, if the
+ * row currently points at some other target the list cannot name, that
+ * target too, so the current value always renders. Ordered so the identity
+ * option comes first.
+ */
+function createdOptionsFor(
+  mapping: AccountMapping,
+  knownTargets: ReadonlySet<string>,
+): Array<{ value: string; name: string }> {
+  const options: Array<{ value: string; name: string }> = []
+  if (!knownTargets.has(mapping.sourceAccount) && isValidBASRange(mapping.sourceAccount)) {
+    options.push({
+      value: mapping.sourceAccount,
+      name: mapping.sourceName || `Konto ${mapping.sourceAccount}`,
+    })
+  }
+  if (
+    mapping.targetAccount &&
+    mapping.targetAccount !== mapping.sourceAccount &&
+    !knownTargets.has(mapping.targetAccount)
+  ) {
+    options.push({
+      value: mapping.targetAccount,
+      name: mapping.targetName || `Konto ${mapping.targetAccount}`,
+    })
+  }
+  return options
 }
 
 function TruncatedSourceName({ sourceName }: { sourceName: string }) {

--- a/extensions/general/arcim-migration/__tests__/mapping-resolution.test.ts
+++ b/extensions/general/arcim-migration/__tests__/mapping-resolution.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Issue #2212: the guided import's mapping step offered no target for a
+ * Fortnox account that exists in neither the company chart nor BAS (4599),
+ * and the user could not tell whether the import handled it.
+ *
+ * These tests run the exact resolution /sie-data runs (buildMappingTargets
+ * then suggestMappings) and pin the contract the mapping step now renders:
+ *   - an in-range source account the chart lacks resolves to ITSELF and is
+ *     created on import with the class and type the importer derives from
+ *     the number (classifyAccount: the same helper syncMappedAccounts uses);
+ *   - that holds with or without a #KONTO name;
+ *   - a number outside 1000-8999 stays unresolved and blocks the step.
+ */
+import { describe, expect, it } from 'vitest'
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+import { buildMappingTargets } from '../lib/mapping-targets'
+import { suggestMappings, validateMappings, isValidBASRange } from '@/lib/import/account-mapper'
+import { classifyAccount } from '@/lib/bookkeeping/account-classifier'
+import { getBASReference } from '@/lib/bookkeeping/bas-reference'
+
+/** A company whose chart holds only the given rows (one page, then empty). */
+function supabaseWithChart(rows: Array<Record<string, unknown>>): SupabaseClient {
+  let served = false
+  const builder = {
+    select: () => builder,
+    eq: () => builder,
+    order: () => builder,
+    range: () => Promise.resolve({ data: served ? [] : ((served = true), rows), error: null }),
+  }
+  return { from: () => builder } as unknown as SupabaseClient
+}
+
+describe('guided import: resolving a source account the target chart lacks', () => {
+  it('4599 is in neither BAS nor an empty chart, so no dropdown target exists for it', async () => {
+    expect(getBASReference('4599')).toBeUndefined()
+    const targets = await buildMappingTargets(supabaseWithChart([]), 'company-1')
+    expect(targets.find((t) => t.account_number === '4599')).toBeUndefined()
+  })
+
+  // The user's case: a #KONTO row with a name and no postings in any exported
+  // year. It resolves to itself; the import creates it under the file's name.
+  it('self-maps a named #KONTO-only account onto its own number', async () => {
+    const targets = await buildMappingTargets(supabaseWithChart([]), 'company-1')
+    const [mapping] = suggestMappings([{ number: '4599', name: 'Justering inköp' }], targets)
+
+    expect(mapping.targetAccount).toBe('4599')
+    expect(mapping.targetName).toBe('Justering inköp')
+    expect(mapping.matchType).toBe('bas_range')
+    expect(validateMappings([mapping]).valid).toBe(true)
+  })
+
+  // The other route to the same screen: an account referenced by #TRANS/#IB
+  // without a #KONTO row arrives nameless. It must resolve the same way; the
+  // importer names it "Konto 4599" (account-sync fallback, tested there).
+  it('self-maps a nameless account referenced only by transactions', async () => {
+    const targets = await buildMappingTargets(supabaseWithChart([]), 'company-1')
+    const [mapping] = suggestMappings([{ number: '4599', name: '' }], targets)
+
+    expect(mapping.targetAccount).toBe('4599')
+    expect(mapping.matchType).toBe('bas_range')
+    expect(validateMappings([mapping]).valid).toBe(true)
+  })
+
+  // The type the created account gets is derived from the number range by
+  // the importer's own classifier, never asked of the user.
+  it('derives the created account type from the number range', () => {
+    expect(classifyAccount('4599')).toEqual({ account_type: 'expense', normal_balance: 'debit' })
+    expect(classifyAccount('1932')).toEqual({ account_type: 'asset', normal_balance: 'debit' })
+    expect(classifyAccount('2093')).toEqual({ account_type: 'equity', normal_balance: 'credit' })
+  })
+
+  // Nothing can be created for a number outside BAS: the step must block and
+  // the user must pick a chart account for its postings.
+  it('leaves an out-of-range account unresolved so the step blocks', async () => {
+    const targets = await buildMappingTargets(supabaseWithChart([]), 'company-1')
+    const [mapping] = suggestMappings([{ number: '9100', name: 'Internt konto' }], targets)
+
+    expect(mapping.targetAccount).toBe('')
+    expect(isValidBASRange('9100')).toBe(false)
+    expect(validateMappings([mapping])).toMatchObject({ valid: false, unmappedAccounts: ['9100'] })
+  })
+
+  // A company that already renamed the account keeps its own row as the
+  // target (exact match on the chart), so nothing is created twice.
+  it('prefers the company row when the account already exists in the chart', async () => {
+    const targets = await buildMappingTargets(
+      supabaseWithChart([{ account_number: '4599', account_name: 'Eget namn', account_class: 4 }]),
+      'company-1',
+    )
+    const [mapping] = suggestMappings([{ number: '4599', name: 'Justering inköp' }], targets)
+
+    expect(mapping.targetAccount).toBe('4599')
+    expect(mapping.targetName).toBe('Eget namn')
+    expect(mapping.matchType).toBe('exact')
+  })
+})

--- a/lib/import/__tests__/account-mapper.test.ts
+++ b/lib/import/__tests__/account-mapper.test.ts
@@ -108,6 +108,20 @@ describe('suggestMappings', () => {
     expect(result[0].matchType).toBe('bas_range')
   })
 
+  // Issue #2212: an account referenced only by #TRANS/#IB arrives without a
+  // #KONTO name. Refusing the self-map left it unmapped with no self-target to
+  // pick, while the parser had already promised it would be created.
+  it('self-maps a nameless in-range account (referenced without #KONTO)', () => {
+    const source = [makeSIEAccount('4599', '')]
+    const result = suggestMappings(source, basAccounts)
+
+    expect(result).toHaveLength(1)
+    expect(result[0].targetAccount).toBe('4599')
+    expect(result[0].targetName).toBe('')
+    expect(result[0].matchType).toBe('bas_range')
+    expect(result[0].confidence).toBe(0.7)
+  })
+
   it('does not self-map accounts outside BAS range (9000+)', () => {
     const source = [makeSIEAccount('9100', 'Internt konto')]
     const result = suggestMappings(source, basAccounts)

--- a/lib/import/__tests__/sie-import.test.ts
+++ b/lib/import/__tests__/sie-import.test.ts
@@ -6,6 +6,7 @@ import {
   ensureFiscalPeriod,
   precheckFiscalPeriod,
   importVouchers,
+  summarizeUnmappedSkips,
   computeVoucherNumberRanges,
   linkOpeningBalanceEntryToPeriod,
   companyHasPriorActivity,
@@ -1843,5 +1844,27 @@ describe('precheckFiscalPeriod', () => {
     await expect(
       ensureFiscalPeriod(again.supabase as unknown as Supabase, 'company-id', '2025-03-01', '2026-02-28'),
     ).rejects.toThrow(precheck.verdict === 'conflict' ? precheck.message : 'unreachable')
+  })
+})
+
+describe('summarizeUnmappedSkips', () => {
+  // Issue #2212: the result step must name WHICH accounts excluded vouchers,
+  // not just how many vouchers were excluded.
+  it('counts vouchers per unmapped account, most excluded first', () => {
+    const summary = summarizeUnmappedSkips([
+      { reason: 'unmapped', unmappedAccounts: ['0099'] },
+      { reason: 'unmapped', unmappedAccounts: ['0099', '9100'] },
+      { reason: 'unmapped', unmappedAccounts: ['9100', '9100'] },
+      { reason: 'unbalanced' },
+      { reason: 'single_line', unmappedAccounts: ['0099'] },
+    ])
+    expect(summary).toEqual([
+      { account: '0099', vouchers: 2 },
+      { account: '9100', vouchers: 2 },
+    ])
+  })
+
+  it('is empty when nothing was skipped for a missing mapping', () => {
+    expect(summarizeUnmappedSkips([{ reason: 'empty' }])).toEqual([])
   })
 })

--- a/lib/import/account-mapper.ts
+++ b/lib/import/account-mapper.ts
@@ -47,8 +47,13 @@ export function isSystemAccount(accountNumber: string): boolean {
 /**
  * Check if an account number is in the valid BAS range (1000-8999).
  * Standard Swedish BAS accounts are 4-digit numbers in classes 1-8.
+ *
+ * This is the auto-create boundary: a source account in this range can
+ * always be carried into the chart under its own number (the importer derives
+ * class and type from the number), so it never needs a manual target. Outside
+ * it (class 9, 5-digit numbers) the user must pick a target.
  */
-function isValidBASRange(accountNumber: string): boolean {
+export function isValidBASRange(accountNumber: string): boolean {
   if (!/^\d{4}$/.test(accountNumber)) return false
   const num = parseInt(accountNumber, 10)
   return num >= 1000 && num <= 8999
@@ -109,8 +114,16 @@ function findBestMatch(
 
   // Fallback: if the account is a valid BAS-range number (1000-8999),
   // self-map it using the name from the SIE file. These are standard
-  // BAS sub-accounts not in our reference (e.g. 1241 Personbilar).
-  if (isValidBASRange(source.number) && source.name) {
+  // BAS sub-accounts not in our reference (e.g. 1241 Personbilar), or
+  // accounts a source system kept outside BAS (e.g. a Fortnox chart's 4599).
+  //
+  // A missing name is not a reason to refuse: an account referenced only by
+  // #TRANS/#IB (no #KONTO row) arrives nameless, and the parser has already
+  // told the user it will be created. The number alone determines class and
+  // type; the importer names it "Konto <nr>" when the file has no name.
+  // Leaving it unmapped offered no way forward except merging it into a
+  // different account, which is wrong for a ledger migration (issue #2212).
+  if (isValidBASRange(source.number)) {
     return {
       sourceAccount: source.number,
       sourceName: source.name,

--- a/lib/import/sie-import.ts
+++ b/lib/import/sie-import.ts
@@ -1214,6 +1214,29 @@ export async function resyncNextPeriodOpeningBalance(
   }
 }
 
+
+/**
+ * Roll the per-voucher unmapped skips up per source account: which accounts
+ * had no mapping and how many vouchers each one excluded. Sorted by voucher
+ * count (most excluded first), then by account number, so the result step
+ * names the account that matters most first. Pure: exported for tests and
+ * for the result surface (ImportResultDetails.skippedVouchers.unmappedAccounts).
+ */
+export function summarizeUnmappedSkips(
+  skippedDetails: ReadonlyArray<{ reason: string; unmappedAccounts?: string[] }>,
+): Array<{ account: string; vouchers: number }> {
+  const perAccount = new Map<string, number>()
+  for (const detail of skippedDetails) {
+    if (detail.reason !== 'unmapped') continue
+    for (const account of new Set(detail.unmappedAccounts ?? [])) {
+      perAccount.set(account, (perAccount.get(account) ?? 0) + 1)
+    }
+  }
+  return [...perAccount]
+    .map(([account, vouchers]) => ({ account, vouchers }))
+    .sort((a, b) => b.vouchers - a.vouchers || a.account.localeCompare(b.account))
+}
+
 /**
  * Create journal entries from vouchers using batch insert for performance.
  *
@@ -2512,6 +2535,7 @@ export async function executeSIEImport(
     let voucherNumberMapping: Array<{ sourceId: string; series: string; targetNumber: number }> = []
     let voucherSeriesUsed: string[] = []
     let voucherRetryStats = { retriedBatches: 0, failedBatches: 0 }
+    let unmappedSkipSummary: Array<{ account: string; vouchers: number }> = []
     let voucherStats = {
       total: parsed.vouchers.length,
       imported: 0,
@@ -2904,12 +2928,17 @@ export async function executeSIEImport(
       }
 
       // Report skipped vouchers as warnings
+      unmappedSkipSummary = summarizeUnmappedSkips(voucherResults.skippedDetails)
       const totalSkipped = voucherResults.skippedEmpty + voucherResults.skippedSingleLine + voucherResults.skippedUnbalanced + voucherResults.skippedUnmapped
       if (totalSkipped > 0) {
         const parts: string[] = []
         if (voucherResults.skippedEmpty > 0) parts.push(`${voucherResults.skippedEmpty} ${voucherResults.skippedEmpty === 1 ? 'tom' : 'tomma'}`)
         if (voucherResults.skippedUnbalanced > 0) parts.push(`${voucherResults.skippedUnbalanced} obalanserade`)
-        if (voucherResults.skippedUnmapped > 0) parts.push(`${voucherResults.skippedUnmapped} med ej mappade konton`)
+        if (voucherResults.skippedUnmapped > 0) {
+          parts.push(
+            `${voucherResults.skippedUnmapped} med ej mappade konton (${unmappedSkipSummary.map((a) => a.account).join(', ')})`
+          )
+        }
         result.warnings.push(
           `${totalSkipped} ${totalSkipped === 1 ? 'verifikation' : 'verifikationer'} hoppades över (${totalSkipped === 1 ? 'ofullständig' : 'ofullständiga'} i källsystemet): ${parts.join(', ')}`
         )
@@ -3083,6 +3112,7 @@ export async function executeSIEImport(
         singleLine: voucherStats.skippedSingleLine,
         empty: voucherStats.skippedEmpty,
         total: totalSkippedForDetails,
+        ...(unmappedSkipSummary.length > 0 ? { unmappedAccounts: unmappedSkipSummary } : {}),
       } : undefined,
       openingBalance: ibRoundingAdjustment !== 0 ? {
         imbalance: ibRoundingAdjustment,

--- a/lib/import/types.ts
+++ b/lib/import/types.ts
@@ -253,6 +253,14 @@ export interface ImportResultDetails {
     singleLine: number
     empty: number
     total: number
+    /**
+     * The source accounts behind `unmapped`, with how many vouchers each one
+     * excluded. Lets the result step name the accounts instead of leaving
+     * the user to diff the general ledger against the source system
+     * (issue #2212). Absent when `unmapped` is 0 and on results recorded
+     * before this field existed.
+     */
+    unmappedAccounts?: Array<{ account: string; vouchers: number }>
   }
 
   /** Opening balance imbalance info */

--- a/messages/en.json
+++ b/messages/en.json
@@ -5472,7 +5472,12 @@
     "vat_review_filter": "{count} VAT treatments to review",
     "vat_treatment_column": "VAT treatment",
     "vat_treatment_confirm": "Confirm",
-    "vat_treatment_confirm_help": "Accept the VAT code for this row to mark it as reviewed. Change the VAT code or rate first if the suggestion is wrong."
+    "vat_treatment_confirm_help": "Accept the VAT code for this row to mark it as reviewed. Change the VAT code or rate first if the suggestion is wrong.",
+    "new_account_filter": "{count} new accounts to create",
+    "new_account_option": "created on import",
+    "source_name_missing": "no name in the file",
+    "unmapped_out_of_range_help": "Accounts outside the BAS range 1000-8999 cannot be created automatically. Choose which account in the chart their postings should go to: {accounts}.",
+    "mapping_new_accounts_note": "Accounts missing from the chart are created on import with the name from the source system and the type derived from the account number."
   },
   "dimensions": {
     "new_value": "New value",
@@ -5642,6 +5647,7 @@
     "ext_email_description": "Send invoices and reminders via email",
     "ext_email_long_description": "Enables email features: send invoices to customers, automatic payment reminders on your chosen schedule, and email notifications. Requires a Resend account with a verified domain or your own SMTP server.",
     "ext_arcim_migration_name": "System migration",
+    "ext_arcim_accounts_created": "{count, plural, one {# new account was added to the chart of accounts with its name from the source system.} other {# new accounts were added to the chart of accounts with names from the source system.}}",
     "ext_arcim_registration_links_label": "Voucher links",
     "ext_arcim_registration_links_value": "{linked} of {scanned} invoices linked to their booking voucher",
     "ext_arcim_registration_links_detail": "{unlinked} not linked: {noRef} without a voucher number at the provider, {refNotFetched} whose provider details could not be fetched in time, {unresolved} without an unambiguous booking voucher, {amountMismatch} with a differing amount",

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -5472,7 +5472,12 @@
     "vat_review_filter": "{count} momskoder att granska",
     "vat_treatment_column": "Momskod",
     "vat_treatment_confirm": "Bekräfta",
-    "vat_treatment_confirm_help": "Godkänn momskoden för raden så räknas den som granskad. Ändra momskod eller momssats först om förslaget inte stämmer."
+    "vat_treatment_confirm_help": "Godkänn momskoden för raden så räknas den som granskad. Ändra momskod eller momssats först om förslaget inte stämmer.",
+    "new_account_filter": "{count} nya konton skapas",
+    "new_account_option": "skapas vid importen",
+    "source_name_missing": "namn saknas i filen",
+    "unmapped_out_of_range_help": "Konton utanför BAS-intervallet 1000-8999 kan inte skapas automatiskt. Välj vilket konto i kontoplanen deras poster ska bokföras på: {accounts}.",
+    "mapping_new_accounts_note": "Konton som saknas i kontoplanen skapas vid importen med namnet från källsystemet och kontotyp från kontonumret."
   },
   "dimensions": {
     "new_value": "Nytt värde",
@@ -5642,6 +5647,7 @@
     "ext_email_description": "Skicka fakturor och påminnelser via e-post",
     "ext_email_long_description": "Aktiverar e-postfunktioner: skicka fakturor till kunder, automatiska betalningspåminnelser enligt valt schema, och e-postmeddelanden. Kräver ett Resend-konto med verifierad domän eller en egen SMTP-server.",
     "ext_arcim_migration_name": "Systemmigration",
+    "ext_arcim_accounts_created": "{count, plural, one {# nytt konto lades till i kontoplanen med namn från källsystemet.} other {# nya konton lades till i kontoplanen med namn från källsystemet.}}",
     "ext_arcim_registration_links_label": "Verifikatkoppling",
     "ext_arcim_registration_links_value": "{linked} av {scanned} fakturor kopplade till bokföringsverifikat",
     "ext_arcim_registration_links_detail": "{unlinked} utan koppling: {noRef} saknar verifikatnummer hos leverantören, {refNotFetched} vars detaljer inte hann hämtas från leverantören, {unresolved} utan entydigt bokföringsverifikat, {amountMismatch} med avvikande belopp",


### PR DESCRIPTION
Closes #2212

## What

The guided Fortnox import's mapping step showed account 4599 with a blank Målkonto and no way to pick 4599 in the list, and after the import nothing said what had happened to it. This PR makes "create `<number> <source name>` in the chart" the visible, default resolution for any source account the target chart lacks, blocks the step with an explanation for the only accounts that cannot be created (numbers outside 1000-8999), and makes the result step name created accounts and, per account, the vouchers skipped for a missing mapping.

- `lib/import/account-mapper.ts`: the self-map rule (`bas_range`) no longer requires a `#KONTO` name. An in-range account referenced only by `#TRANS`/`#IB` now resolves to itself like every other in-range account; the importer already names it `Konto <nr>` (account-sync fallback). `isValidBASRange` is exported as the one auto-create boundary.
- `components/import/AccountMappingStep.tsx` (shared by the guided and the manual wizard): a mapped target the dropdown cannot name is rendered as an explicit option `4599 Namn (skapas vid importen)` instead of a blank trigger; a `{n} nya konton skapas` badge/filter lists exactly which accounts will be created; a sentence names out-of-range accounts that must be mapped manually; a nameless source shows `namn saknas i filen`; the card description says missing accounts are created on import.
- `lib/import/sie-import.ts` + `types.ts`: `details.skippedVouchers.unmappedAccounts` (account, voucher count) via a pure `summarizeUnmappedSkips`; the skipped-voucher warning names the accounts.
- `ArcimMigrationWorkspace.tsx` result step: "N nya konton lades till i kontoplanen" and "med ej kopplade konton (konto 0099: 3)" instead of a bare count.
- i18n: 5 keys under `chart_of_accounts`, 1 under `extensions`, in both `sv.json` and `en.json`.

No API route or migration changes: the import engine already created these accounts correctly (`syncMappedAccounts`, type derived by `classifyAccount`); the defect was entirely in what the mapping step and result step showed.

## First principles

**1. Why it occurred (mechanism, from the code).** Fortnox exports its whole kontoplan as `#KONTO`, including accounts with no postings in any exported year (invisible in Fortnox's reports, hence "hittar inget på det kontot"). `findBestMatch` self-maps any named 1000-8999 account absent from chart+BAS (`targetAccount: '4599'`, `bas_range`, "Trolig"), so `unmapped` was 0 and the step was shown only for class-4 VAT review. But the Målkonto `Select` is built from chart+BAS only, so Radix rendered the value `'4599'` as a blank trigger: a correctly mapped row looked unmapped, the list (correctly) had no 4599 to pick, and nothing said "this account will be created". Continue was enabled (the row counted as mapped), the import created 4599 with the file's name and a derived type, and the result step never mentioned it. The second route to the same screen: an account referenced only by `#TRANS`/`#IB` gets `name: ''` from the parser and the mapper refused the self-map for nameless accounts, leaving it truly unmapped with no self-target on offer, although the parser's own warning promises "Kontona skapas automatiskt vid import". Both routes share one cause: the step modelled "target" as "an account that already exists somewhere", while the engine's contract is "every mapped target is created if missing".

**2. What was removed or simplified.** The `source.name` condition in the mapper is gone: `unmapped` is now exactly "number outside 1000-8999", one rule instead of two. No new wizard state: the existing Continue gate (`canContinue`) already blocks on unmapped rows, and the `/import-sie` 400 plus `executeSIEImport`'s refusal stay as defense in depth. The "create" outcome reuses the importer's existing creation and classification (`syncMappedAccounts` / `classifyAccount`); no second creation path was written.

**3. Why this beats the issue's proposal.** The issue offered "create automatically OR block". The code already created the account; what was missing was truth on screen, so the fix is transparency plus the one missing self-map case rather than new creation logic. Alternative considered: adding the source accounts themselves to `/sie-data`'s target list (`buildMappingTargets`). Rejected: it would fix only the guided wizard (the manual SIE wizard passes the company chart and has the identical blank-Select failure for any BAS account not yet in the chart), and it would make every dropdown offer every source account. A `#KONTO`-only account (zero postings) IS created: it costs nothing, keeps the chart faithful to the source, and an older year fetched in a later run may post to it; silently dropping it is exactly what confused the user.

## Verification

```
npx vitest run --project unit lib/import/__tests__ extensions/general/arcim-migration/__tests__
 Test Files  37 passed (37)   Tests  558 passed (558)

npx vitest run --project unit app/api/import/sie/__tests__ extensions/general/mcp-server/__tests__/{import-sie-stage,sie-preflight,sie-drop-widget}.test.ts
 Test Files  4 passed (4)   Tests  35 passed (35)

npm run check:lint
no-new-lint-errors: OK: 0 error(s), baseline 0.

node scripts/checks/no-new-type-errors.mjs
only extensions/general/email/lib/smtp-service.ts TS7016 (nodemailer types missing in the shared node_modules; environmental, pre-existing); no other file trips.

npm run check:guards
Antipattern guard passed.

grep "from '@/extensions/" in lib/ app/api/ components/ (excluding allowed dirs): prints nothing.
```

Tests added: `extensions/general/arcim-migration/__tests__/mapping-resolution.test.ts` (4599 has no dropdown target; named and nameless in-range accounts self-map; created type derived from the number; 9100 stays unresolved and blocks; existing company row wins), `lib/import/__tests__/account-mapper.test.ts` (nameless in-range self-map), `lib/import/__tests__/sie-import.test.ts` (`summarizeUnmappedSkips`).

## For the founder

- Visual sign-off on the mapping step: new `{n} nya konton skapas` badge (secondary when > 0) next to `ej mappade`; the Målkonto dropdown's first option for such rows reads `4599 Namn (skapas vid importen)`; a muted sentence appears only when out-of-range accounts block Continue.
- Follow-up, not in this PR: `app/api/import/sie/create-accounts/route.ts` (manual wizard's "Skapa saknade konton") carries a third hand-rolled account classifier that misclassifies class 8 and accepts class-9 numbers that the mapper deliberately refuses. Worth folding onto `classifyAccount` and `isValidBASRange`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019SaJfqNi4VmsG8FMKq99G6
