### PR TITLE
chore(domains): add solbo.accounted.se to the production host inventory

### DIFF
--- a/lib/domains/__tests__/production-white-label-backend.test.ts
+++ b/lib/domains/__tests__/production-white-label-backend.test.ts
@@ -17,6 +17,7 @@ const APPROVED_PRODUCTION_HOSTS = [
   'improveone.accounted.se',
   'm360.accounted.se',
   'redovisningskompaniet.accounted.se',
+  'solbo.accounted.se',
   'willem.accounted.se',
   'ziffr.accounted.se',
 ]

--- a/lib/domains/production-white-label-backend.ts
+++ b/lib/domains/production-white-label-backend.ts
@@ -39,6 +39,7 @@ const CUSTOMER_PRODUCTION_WHITE_LABEL_HOSTS = new Set([
   'improveone.accounted.se',
   'm360.accounted.se',
   'redovisningskompaniet.accounted.se',
+  'solbo.accounted.se',
   'willem.accounted.se',
   'ziffr.accounted.se',
 ])


### PR DESCRIPTION
# What and why

Adds `solbo.accounted.se` to `CUSTOMER_PRODUCTION_WHITE_LABEL_HOSTS` and to the host-by-host test pin.

Solbo was provisioned on prod on 2026-09-01 and never added to the inventory. The `accounted.se` namespace rule already protects the host at runtime, so nothing was exposed; the set is the checked-in inventory that the tests pin host by host, and it had drifted. Follow-up to #2376, which found the gap.

**Why did it occur?** The inventory is hand-maintained and provisioning is manual; the file's own comment explains the namespace rule exists precisely because enumerated lists drift.
**What could be removed?** Nothing here: the set documents the approved hosts, and the runtime protection does not depend on it.
**Best solution?** One line, same shape as every existing entry.

Migrations: none. UI strings: none.

## Checklist

- [x] Title follows Conventional Commits
- [x] Test pin updated (`lib/domains/__tests__/production-white-label-backend.test.ts`)
- [x] No migrations, no UI strings, no extension imports

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NUNB7qjua8EUaJmZgfFscx