### PR TITLE
feat(ui): shell v2 sidebar, sections with sub-items (UI v2 PR 2)

### DIFF
--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -579,7 +579,7 @@ export default async function DashboardLayout({
         <div
           id="dash-shell"
           className="min-h-dvh bg-frame md:flex md:flex-col"
-          style={{ '--nav-w': navCollapsed ? '64px' : '248px' } as React.CSSProperties}
+          style={{ '--nav-w': shell === 'v2' ? '220px' : navCollapsed ? '64px' : '248px' } as React.CSSProperties}
         >
           {/* Skip to content link for keyboard/screen reader users */}
           <a
@@ -612,6 +612,7 @@ export default async function DashboardLayout({
             userName={userProfile?.full_name ?? null}
             userEmail={user.email ?? null}
             initialUiState={uiState}
+            shell={shell}
           />
           <main id="main-content" className={MAIN_PANEL_CLASS} role="main" data-shell={shell}>
             <MainContainer companyId={companyId} shell={shell}>

--- a/components/dashboard/DashboardNav.tsx
+++ b/components/dashboard/DashboardNav.tsx
@@ -71,7 +71,7 @@ import { persistUiState } from '@/lib/ui-state/client'
 import { EXTENSION_REQUIRED_CAPABILITY, type CapabilityKey } from '@/lib/entitlements/keys'
 import type { DashboardShell, EntityType, UserUiState } from '@/types'
 import { SidebarV2 } from './SidebarV2'
-import { NAV_V2_BOTTOM, NAV_V2_COMPANY, NAV_V2_TOP, type NavGateFlags, type NavV2Item } from './nav-v2'
+import { NAV_V2_COMPANY, NAV_V2_TOP, type NavGateFlags, type NavV2Item } from './nav-v2'
 
 void _ENABLED_EXTENSION_IDS
 
@@ -679,7 +679,6 @@ export default function DashboardNav({ companyName: _companyName, entityType, pa
     ? cockpitNavItems.filter(passesGates).map(({ href, labelKey, icon }) => ({ href, labelKey, icon }))
     : gateTree(NAV_V2_TOP)
   const v2Company = cockpitMode ? [] : gateTree(NAV_V2_COMPANY)
-  const v2Bottom = gateTree(NAV_V2_BOTTOM)
   // Att göra carries the whole queue (unbooked rows + staged operations);
   // Transaktioner and Assistentens förslag keep their own share.
   const v2BadgeFor = (href: string): number | null => {
@@ -872,7 +871,6 @@ export default function DashboardNav({ companyName: _companyName, entityType, pa
         <SidebarV2
           top={v2Top}
           company={v2Company}
-          bottom={v2Bottom}
           groupLabel={cockpitMode ? '' : tNav('v2_group_company')}
           label={(key) => tNav(key as NavLabelKey)}
           isActive={isActive}
@@ -882,7 +880,6 @@ export default function DashboardNav({ companyName: _companyName, entityType, pa
           betaLabel={tNav('badge_beta')}
           mainNavLabel={tNav('main_navigation')}
           brand={<BrandHomeLink showLabel />}
-          switcher={<CompanySwitcher />}
           backLink={
             byraTeam && !cockpitMode ? (
               <div className="mb-2">

--- a/components/dashboard/DashboardNav.tsx
+++ b/components/dashboard/DashboardNav.tsx
@@ -69,7 +69,9 @@ import { useRealtimeSupabase } from '@/lib/hooks/use-realtime-supabase'
 import { useWorklistBadges } from '@/lib/hooks/use-worklist-badges'
 import { persistUiState } from '@/lib/ui-state/client'
 import { EXTENSION_REQUIRED_CAPABILITY, type CapabilityKey } from '@/lib/entitlements/keys'
-import type { EntityType, UserUiState } from '@/types'
+import type { DashboardShell, EntityType, UserUiState } from '@/types'
+import { SidebarV2 } from './SidebarV2'
+import { NAV_V2_BOTTOM, NAV_V2_COMPANY, NAV_V2_TOP, type NavGateFlags, type NavV2Item } from './nav-v2'
 
 void _ENABLED_EXTENSION_IDS
 
@@ -116,6 +118,9 @@ interface DashboardNavProps {
   // Server-read user_preferences.ui_state: seeds sidebar collapse + fold
   // state so the first client render matches the server-stamped width.
   initialUiState?: UserUiState
+  // Dashboard shell (ui_state.shell). 'v2' swaps the desktop sidebar for
+  // SidebarV2 (220px, sections with sub-items); mobile nav is shared.
+  shell?: DashboardShell
 }
 
 type NavLabelKey =
@@ -356,7 +361,7 @@ const groupLabelKey: Record<Exclude<GroupKey, 'top'>, string> = {
   skatt: 'group_tax',
 }
 
-export default function DashboardNav({ companyName: _companyName, entityType, paysSalaries = false, dimensionsEnabled = false, salesOrdersEnabled = false, hasWebshop = false, hasMileage = false, hasExpenseClaims = false, isSandbox = false, extensionNavItems = [], userName = null, userEmail = null, initialUiState }: DashboardNavProps) {
+export default function DashboardNav({ companyName: _companyName, entityType, paysSalaries = false, dimensionsEnabled = false, salesOrdersEnabled = false, hasWebshop = false, hasMileage = false, hasExpenseClaims = false, isSandbox = false, extensionNavItems = [], userName = null, userEmail = null, initialUiState, shell = 'v1' }: DashboardNavProps) {
   const pathname = usePathname()
   const router = useRouter()
   const supabase = useRealtimeSupabase()
@@ -601,7 +606,9 @@ export default function DashboardNav({ companyName: _companyName, entityType, pa
 
   const isEmployer = entityType === 'aktiebolag' || paysSalaries
 
-  const filteredItems = (cockpitMode ? cockpitNavItems : navItems).filter(item => {
+  // One gate for both shells: a surface hides for the same reason in the
+  // v1 rail and the v2 section tree (nav-v2.ts).
+  const passesGates = (item: NavGateFlags) => {
     if (item.hidden) return false
     if (hiddenNavHrefs.has(item.href)) return false
     // Payroll (employerOnly) is hidden until the company is an employer, an
@@ -638,7 +645,8 @@ export default function DashboardNav({ companyName: _companyName, entityType, pa
     // surfaces the count when there are pending ops, but the link is
     // always present so users can navigate there manually.
     return true
-  })
+  }
+  const filteredItems = (cockpitMode ? cockpitNavItems : navItems).filter(passesGates)
 
   const topItems = filteredItems.filter((i) => i.group === 'top')
 
@@ -662,6 +670,25 @@ export default function DashboardNav({ companyName: _companyName, entityType, pa
   // Flat leaf list for the collapsed 64px icon rail: fold children render
   // as plain icons (group headers and fold headers disappear).
   const railItems = [...topItems, ...sidebarGroups.flatMap(({ items }) => items)]
+
+  // Shell v2 tree: the same gates applied to sections and their sub-items.
+  // In cockpit mode the lean cockpit list is the whole sidebar.
+  const gateTree = (items: NavV2Item[]): NavV2Item[] =>
+    items.filter(passesGates).map((i) => ({ ...i, sub: i.sub?.filter(passesGates) }))
+  const v2Top: NavV2Item[] = cockpitMode
+    ? cockpitNavItems.filter(passesGates).map(({ href, labelKey, icon }) => ({ href, labelKey, icon }))
+    : gateTree(NAV_V2_TOP)
+  const v2Company = cockpitMode ? [] : gateTree(NAV_V2_COMPANY)
+  const v2Bottom = gateTree(NAV_V2_BOTTOM)
+  // Att göra carries the whole queue (unbooked rows + staged operations);
+  // Transaktioner and Assistentens förslag keep their own share.
+  const v2BadgeFor = (href: string): number | null => {
+    if (href === '/' && !cockpitMode) {
+      const n = uncategorizedCount + pendingOpsCount
+      return n > 0 ? n : null
+    }
+    return badgeFor(href)
+  }
 
   const allMobileNavItems: { href: string; labelKey: NavLabelKey; icon: typeof LayoutDashboard }[] = cockpitMode
     ? cockpitNavItems.map(({ href, labelKey, icon }) => ({ href, labelKey, icon }))
@@ -839,9 +866,69 @@ export default function DashboardNav({ companyName: _companyName, entityType, pa
 
   return (
     <>
-      {/* Desktop sidebar */}
-      {/* Width, and the panel margin beside it, share the same 300ms
-          decelerating curve so collapse reads as one movement. */}
+      {/* Desktop sidebar. Shell v2 renders SidebarV2 instead; the mobile
+          nav below is shared by both shells. */}
+      {shell === 'v2' ? (
+        <SidebarV2
+          top={v2Top}
+          company={v2Company}
+          bottom={v2Bottom}
+          groupLabel={cockpitMode ? '' : tNav('v2_group_company')}
+          label={(key) => tNav(key as NavLabelKey)}
+          isActive={isActive}
+          isEnabled={isItemEnabled}
+          badgeFor={v2BadgeFor}
+          needsCompanyTitle={tNav('needs_company_tooltip')}
+          betaLabel={tNav('badge_beta')}
+          mainNavLabel={tNav('main_navigation')}
+          brand={<BrandHomeLink showLabel />}
+          switcher={<CompanySwitcher />}
+          backLink={
+            byraTeam && !cockpitMode ? (
+              <div className="mb-2">
+                {cockpitExternal ? (
+                  <a
+                    href={cockpitHref}
+                    title={cockpitHint ?? undefined}
+                    className="group flex items-center rounded-lg px-3 py-[7px] text-[13px] text-muted-foreground transition-colors duration-150 hover:bg-secondary/60 hover:text-foreground"
+                  >
+                    <ArrowLeft className="mr-2.5 h-[15px] w-[15px] flex-shrink-0" />
+                    <span className="flex-1 min-w-0">
+                      <span className="block">{tNav('back_to_clients')}</span>
+                      <span className="block truncate text-[11px] text-muted-foreground">{cockpitHint}</span>
+                    </span>
+                  </a>
+                ) : (
+                  <NavLink
+                    href={cockpitHref}
+                    className="group flex items-center rounded-lg px-3 py-[7px] text-[13px] text-muted-foreground transition-colors duration-150 hover:bg-secondary/60 hover:text-foreground"
+                  >
+                    <ArrowLeft className="mr-2.5 h-[15px] w-[15px] flex-shrink-0" />
+                    <span className="flex-1">{tNav('back_to_clients')}</span>
+                  </NavLink>
+                )}
+                <div className="mx-3 mt-2 border-t border-border/60" />
+              </div>
+            ) : null
+          }
+          userBlock={
+            <div className="flex-shrink-0">
+              <SubscriptionTouchpoint variant="sidebar" collapsed={false} />
+              <div className="mx-3 border-t border-border/60" />
+              <div className="px-3 py-2">
+                <UserMenu
+                  userName={userName}
+                  userEmail={userEmail}
+                  isSandbox={isSandbox}
+                  collapsed={false}
+                  cockpitMode={cockpitMode}
+                  onLogout={() => void handleLogout()}
+                />
+              </div>
+            </div>
+          }
+        />
+      ) : (
       <aside className="hidden md:fixed md:inset-y-0 md:z-10 md:flex md:w-[var(--nav-w)] md:flex-col md:transition-[width] md:duration-300 md:ease-[cubic-bezier(0.32,0.72,0,1)]">
         {/* Borderless on the frame: the panel next to it carries the border */}
         <div className="flex min-h-0 flex-1 flex-col bg-transparent">
@@ -1085,6 +1172,7 @@ export default function DashboardNav({ companyName: _companyName, entityType, pa
           </div>
         </div>
       </aside>
+      )}
 
       {/* Mobile bottom navigation. data-mobile-nav is the brand-style hook:
           on branded hosts the brand style block re-tints the bar's tokens

--- a/components/dashboard/SidebarV2.tsx
+++ b/components/dashboard/SidebarV2.tsx
@@ -27,8 +27,8 @@ interface SidebarV2Props {
 
 /**
  * Shell v2 desktop sidebar (dev_docs/ui_v2_build_plan.md, PR 2): 220px,
- * brand and company chip on top, Att göra and Assistent, then the BOLAGET
- * sections. The active section shows its sub-items underneath; the rest
+ * brand on top, Att göra and Assistent, then the BOLAGET sections, and the
+ * company chip at the bottom next to the user. The active section shows its sub-items underneath; the rest
  * stay one line each. No collapse: the prototype has none and the panel
  * is full-bleed anyway. Mobile keeps the v1 bottom nav (DashboardNav).
  */
@@ -124,8 +124,7 @@ export function SidebarV2({
   return (
     <aside className="hidden md:fixed md:inset-y-0 md:z-10 md:flex md:w-[var(--nav-w)] md:flex-col">
       <div className="flex min-h-0 flex-1 flex-col bg-transparent">
-        <div className="flex flex-shrink-0 items-center justify-between pl-5 pr-3 pt-3 pb-1">{brand}</div>
-        <div className="flex-shrink-0 px-3 pb-2">{switcher}</div>
+        <div className="flex flex-shrink-0 items-center justify-between pl-5 pr-3 pt-3 pb-2">{brand}</div>
         <nav
           data-ph-unmask
           aria-label={mainNavLabel}
@@ -145,6 +144,10 @@ export function SidebarV2({
           )}
         </nav>
         <div className="flex-shrink-0 space-y-px px-3 pb-1">{bottom.map((item) => row(item, isActive(item.href)))}</div>
+        {/* The company chip sits with the user, at the bottom (founder call
+            2026-09-07): the nav is about the work, the footer about who and
+            for whom. */}
+        <div className="flex-shrink-0 px-3 pb-1 pt-1">{switcher}</div>
         {userBlock}
       </div>
     </aside>

--- a/components/dashboard/SidebarV2.tsx
+++ b/components/dashboard/SidebarV2.tsx
@@ -8,7 +8,6 @@ import { activeSubHref, type NavV2Item } from './nav-v2'
 interface SidebarV2Props {
   top: NavV2Item[]
   company: NavV2Item[]
-  bottom: NavV2Item[]
   /** BOLAGET group header; empty string hides the group (cockpit mode). */
   groupLabel: string
   label: (labelKey: string) => string
@@ -19,7 +18,6 @@ interface SidebarV2Props {
   betaLabel: string
   mainNavLabel: string
   brand: ReactNode
-  switcher: ReactNode
   /** Byrå members inside a company: the pinned route back to the cockpit. */
   backLink?: ReactNode
   userBlock: ReactNode
@@ -28,14 +26,15 @@ interface SidebarV2Props {
 /**
  * Shell v2 desktop sidebar (dev_docs/ui_v2_build_plan.md, PR 2): 220px,
  * brand on top, Att göra and Assistent, then the BOLAGET sections, and the
- * company chip at the bottom next to the user. The active section shows its sub-items underneath; the rest
- * stay one line each. No collapse: the prototype has none and the panel
- * is full-bleed anyway. Mobile keeps the v1 bottom nav (DashboardNav).
+ * user block at the bottom. Settings, help and the company switcher are in
+ * the user menu, so nothing else sits below the sections (founder call
+ * 2026-09-07). The active section shows its sub-items underneath, folding
+ * open with a short height transition; the rest stay one line each. Mobile
+ * keeps the v1 bottom nav (DashboardNav).
  */
 export function SidebarV2({
   top,
   company,
-  bottom,
   groupLabel,
   label,
   isActive,
@@ -45,7 +44,6 @@ export function SidebarV2({
   betaLabel,
   mainNavLabel,
   brand,
-  switcher,
   backLink,
   userBlock,
 }: SidebarV2Props) {
@@ -58,7 +56,7 @@ export function SidebarV2({
     </span>
   )
 
-  const row = (item: NavV2Item, active: boolean, opts?: { sub?: boolean }) => {
+  const row = (item: NavV2Item, active: boolean, opts?: { sub?: boolean; hidden?: boolean }) => {
     const enabled = isEnabled(item.href) && !item.comingSoon
     const badge = badgeFor(item.href)
     const Icon = item.icon
@@ -95,7 +93,7 @@ export function SidebarV2({
         : 'text-muted-foreground/40 cursor-not-allowed',
     )
     return enabled ? (
-      <NavLink key={item.href} href={item.href} className={baseClass}>
+      <NavLink key={item.href} href={item.href} className={baseClass} tabIndex={opts?.hidden ? -1 : undefined}>
         {content}
       </NavLink>
     ) : (
@@ -109,12 +107,24 @@ export function SidebarV2({
     const subs = item.sub ?? []
     const activeSub = activeSubHref(item, isActive)
     const active = isActive(item.href) || activeSub !== null
+    // The sub-list is always in the tree and folds through grid-template-rows,
+    // so a section opening slides instead of jumping (motion-safe only).
     return (
       <div key={item.href}>
         {row(item, active)}
-        {active && subs.length > 0 && (
-          <div className="ml-[19px] mt-px border-l border-border pl-1.5 py-px space-y-px">
-            {subs.map((s) => row(s, s.href === activeSub, { sub: true }))}
+        {subs.length > 0 && (
+          <div
+            className={cn(
+              'grid transition-[grid-template-rows] duration-200 ease-out motion-reduce:transition-none',
+              active ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]',
+            )}
+            aria-hidden={!active}
+          >
+            <div className="min-h-0 overflow-hidden">
+              <div className="ml-[19px] mt-px border-l border-border pl-1.5 py-px space-y-px">
+                {subs.map((s) => row(s, s.href === activeSub, { sub: true, hidden: !active }))}
+              </div>
+            </div>
           </div>
         )}
       </div>
@@ -143,11 +153,6 @@ export function SidebarV2({
             </div>
           )}
         </nav>
-        <div className="flex-shrink-0 space-y-px px-3 pb-1">{bottom.map((item) => row(item, isActive(item.href)))}</div>
-        {/* The company chip sits with the user, at the bottom (founder call
-            2026-09-07): the nav is about the work, the footer about who and
-            for whom. */}
-        <div className="flex-shrink-0 px-3 pb-1 pt-1">{switcher}</div>
         {userBlock}
       </div>
     </aside>

--- a/components/dashboard/SidebarV2.tsx
+++ b/components/dashboard/SidebarV2.tsx
@@ -1,0 +1,152 @@
+'use client'
+
+import type { ReactNode } from 'react'
+import { NavLink } from './NavLink'
+import { cn } from '@/lib/utils'
+import { activeSubHref, type NavV2Item } from './nav-v2'
+
+interface SidebarV2Props {
+  top: NavV2Item[]
+  company: NavV2Item[]
+  bottom: NavV2Item[]
+  /** BOLAGET group header; empty string hides the group (cockpit mode). */
+  groupLabel: string
+  label: (labelKey: string) => string
+  isActive: (href: string) => boolean
+  isEnabled: (href: string) => boolean
+  badgeFor: (href: string) => number | null
+  needsCompanyTitle: string
+  betaLabel: string
+  mainNavLabel: string
+  brand: ReactNode
+  switcher: ReactNode
+  /** Byrå members inside a company: the pinned route back to the cockpit. */
+  backLink?: ReactNode
+  userBlock: ReactNode
+}
+
+/**
+ * Shell v2 desktop sidebar (dev_docs/ui_v2_build_plan.md, PR 2): 220px,
+ * brand and company chip on top, Att göra and Assistent, then the BOLAGET
+ * sections. The active section shows its sub-items underneath; the rest
+ * stay one line each. No collapse: the prototype has none and the panel
+ * is full-bleed anyway. Mobile keeps the v1 bottom nav (DashboardNav).
+ */
+export function SidebarV2({
+  top,
+  company,
+  bottom,
+  groupLabel,
+  label,
+  isActive,
+  isEnabled,
+  badgeFor,
+  needsCompanyTitle,
+  betaLabel,
+  mainNavLabel,
+  brand,
+  switcher,
+  backLink,
+  userBlock,
+}: SidebarV2Props) {
+  const countBubble = (n: number) => (
+    <span
+      data-ph-mask
+      className="ml-auto flex h-[18px] min-w-[18px] items-center justify-center rounded-full bg-primary px-1 text-[10px] font-semibold text-primary-foreground"
+    >
+      {n > 99 ? '99+' : n}
+    </span>
+  )
+
+  const row = (item: NavV2Item, active: boolean, opts?: { sub?: boolean }) => {
+    const enabled = isEnabled(item.href) && !item.comingSoon
+    const badge = badgeFor(item.href)
+    const Icon = item.icon
+    const content = (
+      <>
+        {!opts?.sub && Icon && (
+          <Icon
+            className={cn(
+              'mr-2.5 h-[15px] w-[15px] flex-shrink-0',
+              active ? 'text-foreground' : 'text-muted-foreground group-hover:text-foreground',
+            )}
+          />
+        )}
+        <span className="flex-1 truncate">{label(item.labelKey)}</span>
+        {item.betaBadge ? (
+          <span className="ml-auto rounded-full bg-muted/60 px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wider text-muted-foreground/70">
+            {betaLabel}
+          </span>
+        ) : (
+          badge !== null && countBubble(badge)
+        )}
+      </>
+    )
+    const baseClass = cn(
+      'group flex items-center rounded-lg',
+      opts?.sub ? 'px-3 py-[5px] text-[12.5px]' : 'px-3 py-[7px] text-[13px]',
+      enabled
+        ? cn(
+            'transition-colors duration-150',
+            active
+              ? 'bg-secondary text-foreground font-medium'
+              : 'text-muted-foreground hover:text-foreground hover:bg-secondary/60',
+          )
+        : 'text-muted-foreground/40 cursor-not-allowed',
+    )
+    return enabled ? (
+      <NavLink key={item.href} href={item.href} className={baseClass}>
+        {content}
+      </NavLink>
+    ) : (
+      <div key={item.href} className={baseClass} aria-disabled="true" title={needsCompanyTitle}>
+        {content}
+      </div>
+    )
+  }
+
+  const section = (item: NavV2Item) => {
+    const subs = item.sub ?? []
+    const activeSub = activeSubHref(item, isActive)
+    const active = isActive(item.href) || activeSub !== null
+    return (
+      <div key={item.href}>
+        {row(item, active)}
+        {active && subs.length > 0 && (
+          <div className="ml-[19px] mt-px border-l border-border pl-1.5 py-px space-y-px">
+            {subs.map((s) => row(s, s.href === activeSub, { sub: true }))}
+          </div>
+        )}
+      </div>
+    )
+  }
+
+  return (
+    <aside className="hidden md:fixed md:inset-y-0 md:z-10 md:flex md:w-[var(--nav-w)] md:flex-col">
+      <div className="flex min-h-0 flex-1 flex-col bg-transparent">
+        <div className="flex flex-shrink-0 items-center justify-between pl-5 pr-3 pt-3 pb-1">{brand}</div>
+        <div className="flex-shrink-0 px-3 pb-2">{switcher}</div>
+        <nav
+          data-ph-unmask
+          aria-label={mainNavLabel}
+          className="min-h-0 flex-1 overflow-y-auto overflow-x-hidden px-3 pt-1 pb-2"
+        >
+          {backLink}
+          <div className="mb-4 space-y-px">{top.map(section)}</div>
+          {company.length > 0 && (
+            <div className="mb-4">
+              {groupLabel && (
+                <div className="px-3 pb-1 text-[10px] font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+                  {groupLabel}
+                </div>
+              )}
+              <div className="space-y-px">{company.map(section)}</div>
+            </div>
+          )}
+        </nav>
+        <div className="flex-shrink-0 space-y-px px-3 pb-1">{bottom.map((item) => row(item, isActive(item.href)))}</div>
+        {userBlock}
+      </div>
+    </aside>
+  )
+}

--- a/components/dashboard/nav-v2.ts
+++ b/components/dashboard/nav-v2.ts
@@ -79,8 +79,8 @@ export const NAV_V2_COMPANY: NavV2Item[] = [
     labelKey: 'v2_invoicing',
     icon: ReceiptText,
     sub: [
+      // Återkommande opens from Ny faktura; it is a way to make invoices, not a place.
       { href: '/invoices', labelKey: 'invoices' },
-      { href: '/invoices/recurring', labelKey: 'v2_recurring' },
       { href: '/sales-orders', labelKey: 'sales_orders', requiresSalesOrders: true },
       { href: '/orders', labelKey: 'webshop_orders', requiresWebshop: true, betaBadge: true },
       { href: '/customers', labelKey: 'customers' },

--- a/components/dashboard/nav-v2.ts
+++ b/components/dashboard/nav-v2.ts
@@ -10,9 +10,6 @@ import {
   Percent,
   BarChart3,
   FileCheck,
-  Puzzle,
-  HelpCircle,
-  Settings,
 } from 'lucide-react'
 import { EXTENSION_REQUIRED_CAPABILITY, type CapabilityKey } from '@/lib/entitlements/keys'
 import type { EntityType } from '@/types'
@@ -43,7 +40,8 @@ export interface NavGateFlags {
  * the prototype's BOLAGET list; a section's sub-items render under it while
  * the section is active, so nothing the v1 rail reached becomes a dead end.
  * Every href here already has a page; PR 3 to PR 8 change what the pages
- * show, not where they live.
+ * show, not where they live. Settings, help and the company switcher live
+ * in the user menu at the bottom, so the sidebar has no bottom group.
  */
 export interface NavV2Item extends NavGateFlags {
   labelKey: string
@@ -159,12 +157,6 @@ export const NAV_V2_COMPANY: NavV2Item[] = [
       { href: '/reports/ne-declaration', labelKey: 'income_declaration', entityOnly: 'enskild_firma' },
     ],
   },
-]
-
-export const NAV_V2_BOTTOM: NavV2Item[] = [
-  { href: '/extensions', labelKey: 'extensions', icon: Puzzle },
-  { href: '/help', labelKey: 'help', icon: HelpCircle },
-  { href: '/settings', labelKey: 'settings', icon: Settings },
 ]
 
 /**

--- a/components/dashboard/nav-v2.ts
+++ b/components/dashboard/nav-v2.ts
@@ -1,0 +1,178 @@
+import type { LucideIcon } from 'lucide-react'
+import {
+  CheckSquare,
+  Sparkles,
+  ArrowLeftRight,
+  ReceiptText,
+  Wallet,
+  BookOpen,
+  HandCoins,
+  Percent,
+  BarChart3,
+  FileCheck,
+  Puzzle,
+  HelpCircle,
+  Settings,
+} from 'lucide-react'
+import { EXTENSION_REQUIRED_CAPABILITY, type CapabilityKey } from '@/lib/entitlements/keys'
+import type { EntityType } from '@/types'
+
+/**
+ * Visibility gates shared by the v1 nav items and the v2 tree. DashboardNav
+ * evaluates them once (passesGates) so a surface hides for exactly the same
+ * reason in both shells.
+ */
+export interface NavGateFlags {
+  href: string
+  employerOnly?: boolean
+  requiresDimensions?: boolean
+  requiresSalesOrders?: boolean
+  requiresWebshop?: boolean
+  requiresMileage?: boolean
+  requiresExpenses?: boolean
+  requiredCapability?: CapabilityKey
+  entityOnly?: EntityType
+  byraOnly?: boolean
+  hidden?: boolean
+  comingSoon?: boolean
+  betaBadge?: boolean
+}
+
+/**
+ * Shell v2 sidebar tree (dev_docs/ui_v2_build_plan.md, PR 2). Sections are
+ * the prototype's BOLAGET list; a section's sub-items render under it while
+ * the section is active, so nothing the v1 rail reached becomes a dead end.
+ * Every href here already has a page; PR 3 to PR 8 change what the pages
+ * show, not where they live.
+ */
+export interface NavV2Item extends NavGateFlags {
+  labelKey: string
+  icon?: LucideIcon
+  sub?: NavV2Item[]
+}
+
+export const NAV_V2_TOP: NavV2Item[] = [
+  {
+    href: '/',
+    labelKey: 'v2_todo',
+    icon: CheckSquare,
+    sub: [{ href: '/pending', labelKey: 'v2_proposals' }],
+  },
+  {
+    href: '/chat',
+    labelKey: 'assistant',
+    icon: Sparkles,
+    sub: [{ href: '/agent-knowledge', labelKey: 'agent_knowledge' }],
+  },
+]
+
+export const NAV_V2_COMPANY: NavV2Item[] = [
+  {
+    href: '/transactions',
+    labelKey: 'transactions',
+    icon: ArrowLeftRight,
+    sub: [
+      { href: '/reconciliation', labelKey: 'reconciliation' },
+      { href: '/parties', labelKey: 'v2_parties' },
+    ],
+  },
+  {
+    href: '/invoices',
+    labelKey: 'v2_invoicing',
+    icon: ReceiptText,
+    sub: [
+      { href: '/invoices', labelKey: 'invoices' },
+      { href: '/invoices/recurring', labelKey: 'v2_recurring' },
+      { href: '/sales-orders', labelKey: 'sales_orders', requiresSalesOrders: true },
+      { href: '/orders', labelKey: 'webshop_orders', requiresWebshop: true, betaBadge: true },
+      { href: '/customers', labelKey: 'customers' },
+      { href: '/articles', labelKey: 'articles' },
+    ],
+  },
+  {
+    href: '/supplier-invoices',
+    labelKey: 'v2_purchases',
+    icon: Wallet,
+    sub: [
+      { href: '/supplier-invoices', labelKey: 'supplier_invoices' },
+      {
+        href: '/e/general/invoice-inbox',
+        labelKey: 'invoice_inbox',
+        requiredCapability: EXTENSION_REQUIRED_CAPABILITY['general/invoice-inbox'],
+      },
+      { href: '/expenses', labelKey: 'expenses', requiresExpenses: true },
+      { href: '/mileage', labelKey: 'mileage', requiresMileage: true },
+      { href: '/supplier-invoices/payment-files', labelKey: 'v2_payment_files' },
+      { href: '/suppliers', labelKey: 'suppliers' },
+    ],
+  },
+  {
+    href: '/bookkeeping',
+    labelKey: 'bookkeeping',
+    icon: BookOpen,
+    sub: [
+      { href: '/bookkeeping', labelKey: 'v2_vouchers' },
+      { href: '/chart-of-accounts', labelKey: 'chart_of_accounts' },
+      { href: '/bookkeeping/periodiseringar', labelKey: 'periodiseringar' },
+      { href: '/assets', labelKey: 'assets' },
+      { href: '/dimensions', labelKey: 'dimensions', requiresDimensions: true },
+      { href: '/import', labelKey: 'import' },
+    ],
+  },
+  {
+    href: '/salary',
+    labelKey: 'salary',
+    icon: HandCoins,
+    employerOnly: true,
+    sub: [
+      { href: '/salary', labelKey: 'v2_salary_runs' },
+      { href: '/salary/employees', labelKey: 'employees' },
+    ],
+  },
+  {
+    href: '/reports/vat-declaration',
+    labelKey: 'v2_tax',
+    icon: Percent,
+    sub: [
+      { href: '/reports/vat-declaration', labelKey: 'vat_declaration' },
+      { href: '/skattekonto', labelKey: 'skattekonto' },
+      { href: '/deadlines', labelKey: 'deadlines' },
+    ],
+  },
+  {
+    href: '/reports',
+    labelKey: 'reports',
+    icon: BarChart3,
+    sub: [
+      { href: '/reports', labelKey: 'reports' },
+      { href: '/kpi', labelKey: 'kpi' },
+    ],
+  },
+  {
+    href: '/bookkeeping/year-end',
+    labelKey: 'v2_closing',
+    icon: FileCheck,
+    sub: [
+      { href: '/bookkeeping/year-end', labelKey: 'year_end' },
+      { href: '/bookkeeping/year-end/arsredovisning', labelKey: 'annual_report', entityOnly: 'aktiebolag' },
+      { href: '/reports/ink2-declaration', labelKey: 'income_declaration', entityOnly: 'aktiebolag' },
+      { href: '/reports/ne-declaration', labelKey: 'income_declaration', entityOnly: 'enskild_firma' },
+    ],
+  },
+]
+
+export const NAV_V2_BOTTOM: NavV2Item[] = [
+  { href: '/extensions', labelKey: 'extensions', icon: Puzzle },
+  { href: '/help', labelKey: 'help', icon: HelpCircle },
+  { href: '/settings', labelKey: 'settings', icon: Settings },
+]
+
+/**
+ * Longest matching sub-item wins, so /invoices/recurring lights up
+ * Återkommande and not Kundfakturor as well.
+ */
+export function activeSubHref(item: NavV2Item, isActive: (href: string) => boolean): string | null {
+  const matches = (item.sub ?? []).filter((s) => isActive(s.href))
+  if (matches.length === 0) return null
+  return matches.reduce((best, s) => (s.href.length > best.href.length ? s : best)).href
+}

--- a/dev_docs/ui_v2_build_plan.md
+++ b/dev_docs/ui_v2_build_plan.md
@@ -28,7 +28,7 @@ Done when: any page renders in both shells, the toggle persists, lint and tests 
 ### PR 2: sidebar and top bar to the prototype's proportions
 
 - Sidebar 220 px with 15 px icons, company chip at the top, Enheter group.
-- Top bar gets the plus, the comment bubble placeholder and the avatar menu (Mitt konto / Bolaget).
+- The avatar menu stays at the bottom of the sidebar in PR 2; moving it and the plus into the top bar is part of PR 9 (cutover polish), since the top bar is the page header and lives inside each page.
 - Nav IA: Att göra, Aktivitet, then Konton, Transaktioner, Fakturering, Inköp, Bokföring, Löner, Skatt, Rapporter, Bokslut. Sub-pages become section pickers in the toolbar row instead of nav items.
 
 ### PR 3: Att göra as three panes on the worklist

--- a/messages/en.json
+++ b/messages/en.json
@@ -111,7 +111,19 @@
     "subscription": "Subscription",
     "trial_expired_cta": "Trial ended · Upgrade",
     "subscription_lapsed_cta": "Subscription ended · Reactivate",
-    "discord_community": "Discord community"
+    "discord_community": "Discord community",
+    "v2_todo": "To do",
+    "v2_proposals": "Assistant proposals",
+    "v2_group_company": "The company",
+    "v2_invoicing": "Invoicing",
+    "v2_purchases": "Purchases",
+    "v2_tax": "Tax",
+    "v2_closing": "Year-end",
+    "v2_vouchers": "Journal entries",
+    "v2_salary_runs": "Payroll runs",
+    "v2_recurring": "Recurring",
+    "v2_payment_files": "Payment files",
+    "v2_parties": "Counterparties"
   },
   "trial_expired_dialog": {
     "title": "Your trial has expired",

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -111,7 +111,19 @@
     "subscription": "Abonnemang",
     "trial_expired_cta": "Provperioden är slut · Uppgradera",
     "subscription_lapsed_cta": "Abonnemanget har avslutats · Aktivera",
-    "discord_community": "Discord-community"
+    "discord_community": "Discord-community",
+    "v2_todo": "Att göra",
+    "v2_proposals": "Assistentens förslag",
+    "v2_group_company": "Bolaget",
+    "v2_invoicing": "Fakturering",
+    "v2_purchases": "Inköp",
+    "v2_tax": "Skatt",
+    "v2_closing": "Bokslut",
+    "v2_vouchers": "Verifikationer",
+    "v2_salary_runs": "Lönekörningar",
+    "v2_recurring": "Återkommande",
+    "v2_payment_files": "Betalfiler",
+    "v2_parties": "Motparter"
   },
   "trial_expired_dialog": {
     "title": "Din provperiod har löpt ut",


### PR DESCRIPTION
## Summary

PR 2 of the UI v2 plan (`dev_docs/ui_v2_build_plan.md`), stacked on #2379. In shell v2 the desktop sidebar becomes `SidebarV2`: 220 px, brand and company chip on top, Att göra with the whole-queue badge and Assistent, then the BOLAGET sections Transaktioner, Fakturering, Inköp, Bokföring, Löner, Skatt, Rapporter, Bokslut. The active section shows its sub-items underneath (Kontoplan, Betalfiler, Kunder, Anställda, Skattekonto and so on), so nothing the v1 rail reached becomes a dead end.

- `components/dashboard/nav-v2.ts`: the section tree, gated by the same flags as v1 (employer, dimensions, webshop, mileage, expenses, capability, entity type).
- `DashboardNav`: the inline item filter is now `passesGates` and runs for both shells; the `shell` prop selects `SidebarV2` on desktop. Cockpit mode renders the lean byrå list in the same sidebar, with the back-to-clients link inside a company.
- Layout: `--nav-w` is 220 px in v2. v1 desktop, the collapse rail and the mobile bottom nav are untouched.
- Twelve nav labels added in sv and en.

## First principles

- **Why it occurred:** the v1 sidebar grew one row per surface (about 45 links in four groups plus folds). Kick's sidebar has eight sections and the prototype confirmed that reads calmer.
- **What can be removed:** at cutover the v1 aside, the collapse rail and the fold state go away; `passesGates` stays.
- **Why this beats trimming the v1 list:** the tree keeps every page reachable while the top level drops to what a non-accountant thinks in (fakturor, inköp, löner, skatt), and the gates are shared so a hidden surface hides for the same reason in both shells.

## Test plan

- [x] eslint on the changed files, clean
- [x] `tsc --noEmit`: no errors in the touched files (the nodemailer error is the stale local node_modules)
- [ ] Preview with Layout = Fullbredd: sidebar shows the eight sections; open Kontoplan and see it listed under Bokföring; open Betalfiler under Inköp; an enskild firma without pays_salaries has no Löner; the badge on Att göra equals unbooked rows plus staged operations. Layout = Standard is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
