### PR TITLE
fix(templates): short keywords match whole words, so "vercel" is not electricity

### DIFF
--- a/lib/bookkeeping/__tests__/find-matching-templates-keywords.test.ts
+++ b/lib/bookkeeping/__tests__/find-matching-templates-keywords.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import { makeTransaction } from '@/tests/helpers'
+import { findMatchingTemplates } from '../booking-templates'
+
+const top = (description: string) =>
+  findMatchingTemplates(makeTransaction({ description, merchant_name: null, amount: -1230.97, mcc_code: null }))[0]?.template.id
+
+describe('findMatchingTemplates keyword matching', () => {
+  it('does not read "el" out of "vercel" or "hotel"', () => {
+    expect(top('Vercel Aug')).not.toBe('premises_electricity')
+    expect(top('HOTEL HANSSON K3667')).not.toBe('premises_electricity')
+  })
+
+  it('still matches a whole-word short keyword and the long ones', () => {
+    expect(top('Vattenfall el 2026-08')).toBe('premises_electricity')
+    expect(top('Fjärrvärme Göteborg Energi')).toBe('premises_electricity')
+  })
+})

--- a/lib/bookkeeping/booking-templates.ts
+++ b/lib/bookkeeping/booking-templates.ts
@@ -1795,6 +1795,14 @@ export function stripBankNoise(lowerText: string): string {
  * Multi-signal matching against a transaction.
  * Returns top matches sorted by confidence descending.
  */
+/** Keywords up to this length are matched as whole words; longer ones may sit inside a word ("fjärruppvärmning"). */
+const WHOLE_WORD_KEYWORD_MAX = 3
+
+function keywordMatches(searchText: string, searchWords: ReadonlySet<string>, keyword: string): boolean {
+  if (keyword.length <= WHOLE_WORD_KEYWORD_MAX) return searchWords.has(keyword)
+  return searchText.includes(keyword)
+}
+
 export function findMatchingTemplates(
   transaction: Transaction,
   entityType?: EntityType
@@ -1809,6 +1817,7 @@ export function findMatchingTemplates(
   // Strip bank-method noise so e.g. "Överföring via internet" doesn't make
   // the matcher believe the merchant is "Internet" (→ 6230 telecom).
   const searchText = stripBankNoise(rawSearchText)
+  const searchWords = new Set(searchText.split(/[^\p{L}\p{N}]+/u).filter(Boolean))
 
   for (const t of BOOKING_TEMPLATES) {
     // Filter entity applicability
@@ -1828,11 +1837,13 @@ export function findMatchingTemplates(
       score += 0.4
     }
 
-    // Keyword matches in description + merchant: +0.3 (proportional)
+    // Keyword matches in description + merchant: +0.3 (proportional).
+    // Short keywords match whole words only: "el" inside "vercel" or
+    // "hotel" made El & Uppvärmning the top proposal for a hosting bill.
     if (t.keywords.length > 0) {
       let matchedKeywords = 0
       for (const kw of t.keywords) {
-        if (searchText.includes(kw.toLowerCase())) {
+        if (keywordMatches(searchText, searchWords, kw.toLowerCase())) {
           matchedKeywords++
         }
       }


### PR DESCRIPTION
## What

\`findMatchingTemplates\` matched template keywords as substrings. The two-letter keyword \`el\` on El & Uppvärmning matched inside "vercel" and "hotel", so a Vercel hosting bill and a hotel night both got an electricity booking as their top proposal (seen on Arcim today: "Vercel Aug" → El & Uppvärmning).

Keywords of up to three characters now match whole words only. Longer keywords keep matching inside a word, so "fjärruppvärmning" still finds "uppvärmning".

## First principles

The matcher scored a keyword hit without asking whether the hit was a word. Fixing it at the match beats growing a stop-list of merchants that happen to contain "el".

## Test

\`lib/bookkeeping/__tests__/find-matching-templates-keywords.test.ts\`: "Vercel Aug" and "HOTEL HANSSON" no longer propose \`premises_electricity\`; "Vattenfall el" and "Fjärrvärme" still do. The existing 86 template tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved bookkeeping template matching for short keywords.
  - Short keywords now match only as complete words, preventing false matches within unrelated words.
  - Longer keywords continue to support substring matching.
- **Tests**
  - Added coverage for whole-word matching and longer keyword searches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->