### PR TITLE
fix(invoices): wrap the Visa PDF handler so the click event is not read as options

### DIFF
--- a/app/(dashboard)/invoices/[id]/page.tsx
+++ b/app/(dashboard)/invoices/[id]/page.tsx
@@ -1778,7 +1778,7 @@ export default function InvoiceDetailPage({ params }: { params: Promise<{ id: st
           )}
           {/* Review in the browser (#1190); the download lives in the menu. */}
           {!isSelfBilled && (
-            <Button variant="outline" onClick={previewPDF}>
+            <Button variant="outline" onClick={() => previewPDF()}>
               <Eye className="mr-2 h-4 w-4" />
               {t('preview_pdf')}
             </Button>


### PR DESCRIPTION
# What and why

Refs #2399. Follow-up to #2401, which was merged before Core Build had reported.

The review pass gave `previewPDF` an `options` parameter but left the Visa PDF button's `onClick` as a bare reference, so TypeScript saw a `MouseEvent` flowing into `{ asDraft?: boolean }`. Core Build and the Vercel production deploy on 4e8d649b2 failed; prod stayed on the previous deploy. One-line fix: `onClick={() => previewPDF()}`. No other bare references to `previewPDF` or `downloadPDF` remain (grepped).

Why the local gates missed it: `check:types` passed locally with a total-count ratchet (533 vs baseline 535) while CI's per-file baseline flagged the file. The `npm run build` step is what caught it. Worth a look at the ratchet script separately.

## Migrations

None.

## Tests

`npx tsc --noEmit` reports no errors in the touched invoice files.

## Checklist

- [x] Title follows Conventional Commits
- [x] No migrations
- [x] No imports from `@/extensions/` in core code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZiqSg2v6XrtaFZyyRK88b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Maintained invoice PDF preview behavior when selecting **Review in the browser**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->