### PR TITLE
fix(billing): drop the first-charge date line from the trial view of Abonnemang

### DIFF
--- a/components/settings/sections/BillingSettingsContent.tsx
+++ b/components/settings/sections/BillingSettingsContent.tsx
@@ -300,10 +300,7 @@ function BillingCoreContent() {
     plan === 'yearly'
       ? t('price_note_yearly', { inc: formatCurrency(price.incVat), perMonth: formatCurrency(price.perMonthEquivalent) })
       : t('price_note_monthly', { inc: formatCurrency(price.incVat) })
-  const termsLine =
-    chargeDeferred && trialEndsAt
-      ? t('terms_deferred', { date: formatDateLong(trialEndsAt) })
-      : t('terms_now')
+  const termsLine = t('terms_now')
 
   return (
     <div>

--- a/messages/en.json
+++ b/messages/en.json
@@ -2111,7 +2111,6 @@
     "unlock_webshop_gloss": "orders pulled from WooCommerce and Shopify",
     "unlock_users": "More users",
     "unlock_users_gloss": "invite colleagues, everyone can work in the company",
-    "terms_deferred": "First charge {date}. Cancel any time. Payment via Stripe.",
     "terms_now": "No lock-in, cancel any time. Payment via Stripe.",
     "unlock_help": "The subscription is the external connections: the assistant, your bank, Skatteverket, email, Stripe and the webshops. Without it, bookkeeping, invoicing, reports and SIE export keep working as usual and everything stays: accounting records are kept for seven years under the Swedish Bookkeeping Act regardless of subscription. Start again later and the connections pick up where they left off.",
     "without_note": "Without a subscription only the external connections pause. Everything else stays.",

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -2111,7 +2111,6 @@
     "unlock_webshop_gloss": "ordrar hämtas från WooCommerce och Shopify",
     "unlock_users": "Fler användare",
     "unlock_users_gloss": "bjud in kollegor, alla kan arbeta i företaget",
-    "terms_deferred": "Första debiteringen {date}. Avsluta när du vill. Betalning via Stripe.",
     "terms_now": "Ingen bindningstid, avsluta när du vill. Betalning via Stripe.",
     "unlock_help": "Abonnemanget är de externa kopplingarna: assistenten, banken, Skatteverket, e-post, Stripe och webshoparna. Utan det fortsätter bokföring, fakturering, rapporter och SIE-export som vanligt, och allt finns kvar: räkenskapsinformation bevaras i sju år enligt bokföringslagen oavsett abonnemang. Startar du igen senare fortsätter kopplingarna där de slutade.",
     "without_note": "Utan abonnemang pausas bara de externa kopplingarna. Allt annat finns kvar.",


### PR DESCRIPTION
# What and why

During trial, the Abonnemang page rendered "Första debiteringen <date>. Avsluta när du vill. Betalning via Stripe." whenever the first charge would be deferred to trial end. That is the only sentence on the page that describes a charge as already booked, and trial users read the page as a running subscription with a scheduled payment. Four support mails in two days (2026-09-09 to 2026-09-10) asked how to avoid paying.

**Why the problem occurred:** the trial view is a sell view (price, interval toggle, "Starta" button), but the terms line under the button spoke in the past tense of a subscription that does not exist yet.

**What was removed instead of added:** the deferred branch of `termsLine` and the `terms_deferred` key in sv and en. The trial view now always shows "Ingen bindningstid, avsluta när du vill. Betalning via Stripe." Nothing new is shown; the founder chose removal over adding "gratis, inget kort" copy.

**Why this rather than the proposed alternative:** adding reassurance copy to the nav pill, trial dialog and register page would widen the diff for a problem localised to one sentence. The first-charge date is not lost: the checkout route still passes `trial_end` to Stripe and the hosted checkout states the date when the user opts in. The trial end date also stays on the page in the countdown line. The "0 kr idag" CTA and the deferred checkout logic are unchanged.

Skeptic (three independent passes: correctness, compliance/money, regression): zero refutations.

Migrations: none. Tests: no logic change in `lib/` or `app/api/`; `i18n` key test, lint, `check:types`, `check:guards` green.

Closes #2465

## Checklist

- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `refactor:`, `test:`, `docs:`)
- [x] `npm run lint`, `npm test`, and `npm run build` pass locally (lint, types ratchet and affected tests run locally; CI runs the full suite)
- [x] New or changed logic in `lib/` or `app/api/` has tests (none changed)
- [x] New or changed UI strings exist in both `messages/sv.json` and `messages/en.json`
- [x] Migrations (if any) are new files in `supabase/migrations/`; no edits to already-shipped migrations
- [x] Core builds with zero extensions enabled (no imports from `@/extensions/` in core code)
- [ ] Commits are signed off (`git commit -s`, see [DCO](../DCO))

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011zzGRrSnct7JCgxzpGcjYm


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Billing terms now consistently display the immediate-charge message.
  * Deferred-charge details and the trial-end date are no longer shown in the billing terms line.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->