### PR TITLE
fix(migrations) SQL Crash When applying supabase migration

### DIFF
--- a/supabase/migrations/20260902093000_security_role_gates_membership_and_posting_integrity.sql
+++ b/supabase/migrations/20260902093000_security_role_gates_membership_and_posting_integrity.sql
@@ -766,10 +766,10 @@ $$;
 REVOKE EXECUTE ON FUNCTION public.validate_version_chain(uuid) FROM PUBLIC, anon;
 GRANT EXECUTE ON FUNCTION public.validate_version_chain(uuid) TO authenticated, service_role;
 
-REVOKE EXECUTE ON FUNCTION public.match_documents(vector, integer, double precision) FROM PUBLIC, anon;
-GRANT EXECUTE ON FUNCTION public.match_documents(vector, integer, double precision) TO authenticated, service_role;
-REVOKE EXECUTE ON FUNCTION public.match_booking_templates(vector, integer, double precision) FROM PUBLIC, anon;
-GRANT EXECUTE ON FUNCTION public.match_booking_templates(vector, integer, double precision) TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.match_documents(extensions.vector, integer, double precision) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.match_documents(extensions.vector, integer, double precision) TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.match_booking_templates(extensions.vector, integer, double precision) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.match_booking_templates(extensions.vector, integer, double precision) TO authenticated, service_role;
 
 REVOKE EXECUTE ON FUNCTION public.update_overdue_supplier_invoices() FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION public.update_overdue_supplier_invoices() TO service_role;


### PR DESCRIPTION
I encountered a bug when trying to apply the automatic supabase migration through Supabase CLI. After applyimng the fix I could spin up the container.

Fix for:

Applying migration 20260902093000_security_role_gates_membership_and_posting_integrity.sql... ERROR: type "vector" does not exist (SQLSTATE 42704)

Hint: This type may be defined in a schema that's not in your search_path.
      Use schema-qualified type references to avoid this error:
        CREATE TABLE example (col extensions.vector);
      Learn more: supabase migration new --help
At statement: 31
REVOKE EXECUTE ON FUNCTION public.match_documents(vector, integer, double precision) FROM PUBLIC, anon

# What and why

<!-- What does this PR change, and why? Link related issues with "Closes #123". -->

## Checklist

- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `refactor:`, `test:`, `docs:`)
- [ ] `npm run lint`, `npm test`, and `npm run build` pass locally
- [ ] New or changed logic in `lib/` or `app/api/` has tests
- [ ] New or changed UI strings exist in both `messages/sv.json` and `messages/en.json`
- [ ] Migrations (if any) are new files in `supabase/migrations/`; no edits to already-shipped migrations
- [ ] Core builds with zero extensions enabled (no imports from `@/extensions/` in core code)
- [ ] Commits are signed off (`git commit -s`, see [DCO](../DCO))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Strengthened company data access controls based on membership roles.
  * Restricted ownership, membership, invitation, and team changes to authorized users.
  * Improved document access and storage-location validation.
  * Limited access to administrative and automated operations.

* **Bug Fixes**
  * Prevented invalid journal entries, including unauthorized posting and adding lines to finalized entries.
  * Ensured company creation requires team membership.
  * Improved document version-chain validation for end-user access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->