### PR TITLE
chore(reports): make the trial-balance parity script survive a prod-sized ledger

### DIFF
--- a/scripts/parity-trial-balance-rpc.ts
+++ b/scripts/parity-trial-balance-rpc.ts
@@ -149,6 +149,7 @@ async function outcome(path: 'legacy' | 'rpc', period: PeriodRef, options: Case[
     } catch (err) {
       lastError = err instanceof Error ? err.message : String(err)
       if (!TRANSIENT.test(lastError)) return { ok: false, error: lastError }
+      if (attempt === TRANSIENT_ATTEMPTS) break
       transientRetries += 1
       await sleep(2000 * attempt)
     }
@@ -262,20 +263,19 @@ async function loadDimensionCandidates(client: SupabaseClient): Promise<Map<stri
   return byCompany
 }
 
-/** Probes per period before giving up; bounds the cost for companies with
- *  hundreds of registered objects most periods never use. */
-const MAX_DIMENSION_PROBES = 40
-
 /**
  * The first candidate filter that matches at least one line of the period,
  * found with the RPC itself (jsonb containment on the GIN index, milliseconds
- * per probe). Null when the period carries none of the company's dimensions.
+ * per probe). Every candidate is probed, so null means the period carries
+ * none of the company's registered dimensions: a probe budget would let a
+ * period that uses only a late candidate pass without its dimension case.
+ * The largest prod registry (276 objects) costs about 7 s per period.
  */
 async function findUsedDimension(
   period: PeriodRef,
   candidates: Record<string, string>[],
 ): Promise<Record<string, string> | null> {
-  for (const candidate of candidates.slice(0, MAX_DIMENSION_PROBES)) {
+  for (const candidate of candidates) {
     for (let attempt = 1; attempt <= TRANSIENT_ATTEMPTS; attempt++) {
       const { data, error } = await supabase.rpc('get_trial_balance_aggregates', {
         p_company_id: period.company_id,

--- a/scripts/parity-trial-balance-rpc.ts
+++ b/scripts/parity-trial-balance-rpc.ts
@@ -11,7 +11,9 @@
  *   - one sub-range per period ('include', from = period_start + 90 days,
  *     to = from + 60 days, clipped), which exercises the rollforward bucket;
  *   - one dimension filter per period that has dimension-tagged lines
- *     ('exclude-all-year-end', the P&L convention), sampled up front.
+ *     ('exclude-all-year-end', the P&L convention); the filter is the first
+ *     of the company's registered dimension values that the RPC finds on the
+ *     period's lines.
  *
  * A case where BOTH paths throw the exclude-final fail-closed guard error
  * (a closed period without closing_entry_id) counts as parity; any other
@@ -126,13 +128,36 @@ function runPath(
   }
 }
 
-async function outcome(path: 'legacy' | 'rpc', period: PeriodRef, options: Case['options']): Promise<Outcome> {
-  try {
-    return { ok: true, rows: await runPath(path, period, options) }
-  } catch (err) {
-    return { ok: false, error: err instanceof Error ? err.message : String(err) }
-  }
+/**
+ * A statement timeout or a dropped connection under load says nothing about
+ * parity; retry those a few times with a pause before recording anything.
+ * Every other error is returned as is (and then counted as a diff unless it
+ * is the fail-closed guard on both paths).
+ */
+const TRANSIENT = /statement timeout|fetch failed|ECONNRESET|ETIMEDOUT|socket hang up|502|503|504/i
+const TRANSIENT_ATTEMPTS = 3
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
 }
+
+async function outcome(path: 'legacy' | 'rpc', period: PeriodRef, options: Case['options']): Promise<Outcome> {
+  let lastError = ''
+  for (let attempt = 1; attempt <= TRANSIENT_ATTEMPTS; attempt++) {
+    try {
+      return { ok: true, rows: await runPath(path, period, options) }
+    } catch (err) {
+      lastError = err instanceof Error ? err.message : String(err)
+      if (!TRANSIENT.test(lastError)) return { ok: false, error: lastError }
+      transientRetries += 1
+      await sleep(2000 * attempt)
+    }
+  }
+  return { ok: false, error: lastError }
+}
+
+let transientRetries = 0
+let probeFailures = 0
 
 const AMOUNT_FIELDS: Array<keyof TrialBalanceRow> = [
   'opening_debit',
@@ -203,44 +228,80 @@ function casesFor(period: PeriodRef, dimension: Record<string, string> | null): 
 }
 
 /**
- * Read every dimension-tagged line once (paginated, no cap) and map each to
- * its fiscal period, so every period that carries dimensions gets the
- * dimension case, without a per-period scan.
+ * Candidate dimension filters per company, from the registry
+ * (dimensions x dimension_values = SIE #DIM x #OBJEKT). Every code a line can
+ * carry is registered there (the backfill and the API both write through it),
+ * so probing these candidates finds every period that carries dimensions.
+ * A scan of journal_entry_lines for non-empty dimensions is not an option:
+ * the predicate has no index and the full walk exceeds prod's statement
+ * timeout through PostgREST.
  */
-async function sampleDimensionsByPeriod(client: SupabaseClient): Promise<Map<string, Record<string, string>>> {
-  const lines = await fetchAllRows<{ id: string; journal_entry_id: string; dimensions: Record<string, string> }>(
+async function loadDimensionCandidates(client: SupabaseClient): Promise<Map<string, Record<string, string>[]>> {
+  const dims = await fetchAllRows<{ id: string; company_id: string; sie_dim_no: number }>(({ from, to }) =>
+    client.from('dimensions').select('id, company_id, sie_dim_no').order('id', { ascending: true }).range(from, to),
+  )
+  const dimNo = new Map(dims.map((d) => [d.id, String(d.sie_dim_no)]))
+
+  const values = await fetchAllRows<{ id: string; company_id: string; dimension_id: string; code: string }>(
     ({ from, to }) =>
       client
-        .from('journal_entry_lines')
-        .select('id, journal_entry_id, dimensions')
-        .neq('dimensions', '{}')
+        .from('dimension_values')
+        .select('id, company_id, dimension_id, code')
         .order('id', { ascending: true })
         .range(from, to),
-    { dedupeBy: (r) => r.id },
   )
 
-  const byEntry = new Map<string, Record<string, string>>()
-  for (const line of lines) {
-    const [key, value] = Object.entries(line.dimensions ?? {})[0] ?? []
-    if (key && typeof value === 'string' && !byEntry.has(line.journal_entry_id)) {
-      byEntry.set(line.journal_entry_id, { [key]: value })
-    }
+  const byCompany = new Map<string, Record<string, string>[]>()
+  for (const v of values) {
+    const key = dimNo.get(v.dimension_id)
+    if (!key) continue
+    const list = byCompany.get(v.company_id) ?? []
+    list.push({ [key]: v.code })
+    byCompany.set(v.company_id, list)
   }
+  return byCompany
+}
 
-  const result = new Map<string, Record<string, string>>()
-  const ids = [...byEntry.keys()]
-  for (let i = 0; i < ids.length; i += 100) {
-    const chunk = ids.slice(i, i + 100)
-    const { data: entries, error: entriesError } = await client
-      .from('journal_entries')
-      .select('id, fiscal_period_id')
-      .in('id', chunk)
-    if (entriesError) throw new Error(`mapping dimension samples: ${entriesError.message}`)
-    for (const e of (entries ?? []) as Array<{ id: string; fiscal_period_id: string }>) {
-      if (!result.has(e.fiscal_period_id)) result.set(e.fiscal_period_id, byEntry.get(e.id)!)
+/** Probes per period before giving up; bounds the cost for companies with
+ *  hundreds of registered objects most periods never use. */
+const MAX_DIMENSION_PROBES = 40
+
+/**
+ * The first candidate filter that matches at least one line of the period,
+ * found with the RPC itself (jsonb containment on the GIN index, milliseconds
+ * per probe). Null when the period carries none of the company's dimensions.
+ */
+async function findUsedDimension(
+  period: PeriodRef,
+  candidates: Record<string, string>[],
+): Promise<Record<string, string> | null> {
+  for (const candidate of candidates.slice(0, MAX_DIMENSION_PROBES)) {
+    for (let attempt = 1; attempt <= TRANSIENT_ATTEMPTS; attempt++) {
+      const { data, error } = await supabase.rpc('get_trial_balance_aggregates', {
+        p_company_id: period.company_id,
+        p_fiscal_period_id: period.id,
+        p_closing_mode: 'include',
+        p_from_date: null,
+        p_to_date: null,
+        p_exclude_entry_id: null,
+        p_dimensions: candidate,
+      })
+      if (!error) {
+        if (Array.isArray(data) && data.length > 0) return candidate
+        break
+      }
+      if (!TRANSIENT.test(error.message) || attempt === TRANSIENT_ATTEMPTS) {
+        // A probe that keeps failing must not abort the whole run: the period
+        // is checked without the dimension case and the failure is counted.
+        probeFailures += 1
+        console.log(`  probe failed period=${period.id} dim=${JSON.stringify(candidate)}: ${error.message}`)
+        return null
+      }
+      transientRetries += 1
+      await sleep(2000 * attempt)
     }
   }
-  return result
+  return null
 }
 
 async function main() {
@@ -256,15 +317,16 @@ async function main() {
     return q
   })
   const targets = LIMIT > 0 ? periods.slice(0, LIMIT) : periods
-  const dimensionByPeriod = await sampleDimensionsByPeriod(supabase)
+  const candidatesByCompany = await loadDimensionCandidates(supabase)
 
   console.log(
     `parity: ${targets.length} fiscal periods, ${new Set(targets.map((p) => p.company_id)).size} companies, ` +
-      `${dimensionByPeriod.size} periods with dimension samples, concurrency ${CONCURRENCY}`,
+      `${candidatesByCompany.size} companies with registered dimension values, concurrency ${CONCURRENCY}`,
   )
 
   const diffs: Diff[] = []
   let checks = 0
+  let dimensionPeriods = 0
   let bothFailed = 0
   let legacyMs = 0
   let rpcMs = 0
@@ -273,7 +335,9 @@ async function main() {
   let done = 0
 
   async function checkPeriod(period: PeriodRef) {
-    for (const c of casesFor(period, dimensionByPeriod.get(period.id) ?? null)) {
+    const dimension = await findUsedDimension(period, candidatesByCompany.get(period.company_id) ?? [])
+    if (dimension) dimensionPeriods += 1
+    for (const c of casesFor(period, dimension)) {
       const t0 = Date.now()
       const legacy = await outcome('legacy', period, c.options)
       const t1 = Date.now()
@@ -326,10 +390,18 @@ async function main() {
 
   console.log('')
   console.log(`checks:        ${checks}`)
-  console.log(`both threw:    ${bothFailed} (same error on both paths, counted as parity)`)
+  console.log(`dim periods:   ${dimensionPeriods} (periods that got the dimension case)`)
+  console.log(`probe failed:  ${probeFailures} (periods checked without a dimension case)`)
+  console.log(`retries:       ${transientRetries} (statement timeouts / dropped connections, retried)`)
+  console.log(`both threw:    ${bothFailed} (fail-closed guard on both paths, counted as parity)`)
   console.log(`diffs:         ${diffs.length}`)
   console.log(`legacy total:  ${legacyMs} ms (max ${legacyMaxMs} ms per call)`)
   console.log(`rpc total:     ${rpcMs} ms (max ${rpcMaxMs} ms per call)`)
+
+  if (probeFailures > 0) {
+    console.log('')
+    console.log(`NOT COMPLETE: ${probeFailures} period(s) skipped the dimension case; rerun them with --company`)
+  }
 
   if (diffs.length > 0) {
     console.log('')
@@ -339,6 +411,7 @@ async function main() {
     if (diffs.length > MAX_PRINTED_DIFFS) console.log(`... ${diffs.length - MAX_PRINTED_DIFFS} more`)
     process.exit(1)
   }
+  if (probeFailures > 0) process.exit(1)
   console.log('PARITY OK')
 }
 


### PR DESCRIPTION
# What and why

Refs #2470 (follow-up to #2486). Script only, no product code.

The first read-only prod run of `scripts/parity-trial-balance-rpc.ts` died twice before checking anything:

- Dimension sampling walked `journal_entry_lines` for `dimensions <> '{}'` through PostgREST. No index serves that predicate and the walk over 1.2M lines exceeds prod's 8 s statement timeout. Candidates now come from the `dimensions` / `dimension_values` registry and are probed per period with the RPC itself (jsonb containment on the GIN index, 25 ms per probe on the largest prod period, measured).
- At concurrency 6 the parallel legacy walks loaded prod enough for a 25 ms probe to hit the statement timeout, and one failed probe aborted the run. Transient errors are retried three times with a pause; a probe that still fails skips the dimension case for that period, is counted, and the run exits non-zero as NOT COMPLETE instead of printing PARITY OK.

## Result

Third prod run, concurrency 4, read-only: 10 550 checks over 2 571 fiscal periods (273 with a dimension case), 0 retries, 0 diffs, PARITY OK. Staging smoke: 121 checks, 0 diffs.

## Why the problem occurred

The sampling was written for staging-sized data after CodeRabbit asked for "page through all rows"; the unindexed scan is fine at 50k lines and impossible at 1.2M behind an 8 s cap.

## What was removed

The line scan. The registry already knows every code a line can carry, so no scan is needed.

## Alternative considered

Keyset pagination over the line scan: same total cost, split into pages that each still risk the timeout. Rejected.

## Checklist

- [x] Conventional title
- [x] `eslint` and `tsc` clean on the script
- [x] No lib/api logic, no UI strings, no migrations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012HF5meURZDmzFHiW9jRTV6


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved trial balance parity checks by discovering dimension filters from registered dimension data.
  * Added retry handling for transient errors during filter validation.
  * The process now clearly reports probe failures and exits with an error status when they occur.

* **Reporting**
  * Added metrics for dimension periods, failed probes, and retry attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->