### PR TITLE
fix(peppol): only the access point's own verdict rejects a document; every other answer stays resendable

### DIFF
--- a/app/api/invoices/[id]/peppol/__tests__/route.test.ts
+++ b/app/api/invoices/[id]/peppol/__tests__/route.test.ts
@@ -275,4 +275,23 @@ describe('POST /api/invoices/[id]/peppol', () => {
     expect(body.error.code).toBe(expectedCode)
     expect(body.error.details).toMatchObject({ pgCode: code })
   })
+
+  it('names the missing fiscal year when the stage RPC has no retention basis for the invoice date', async () => {
+    enqueue({ data: invoice, error: null })
+    enqueue({ data: company, error: null })
+    enqueue({
+      data: null,
+      error: { code: 'P0002', message: 'Peppol delivery requires a fiscal period retention basis' },
+    })
+
+    const response = await POST(
+      createMockRequest(`/api/invoices/${INVOICE_ID}/peppol`, { method: 'POST' }),
+      createMockRouteParams({ id: INVOICE_ID }),
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(422)
+    expect(body.error.code).toBe('PEPPOL_FISCAL_PERIOD_MISSING')
+    expect(body.error.details).toMatchObject({ invoice_date: '2026-08-13' })
+  })
 })

--- a/app/api/invoices/[id]/peppol/route.ts
+++ b/app/api/invoices/[id]/peppol/route.ts
@@ -5,7 +5,7 @@ import { privateNoStore } from '@/lib/api/private-no-store'
 import { withRouteContext } from '@/lib/api/with-route-context'
 import { errorResponse, errorResponseFromCode } from '@/lib/errors/get-structured-error'
 import { ensureInitialized } from '@/lib/init'
-import { stagePeppolDelivery } from '@/lib/invoices/peppol-delivery'
+import { isFiscalPeriodMissingError, stagePeppolDelivery } from '@/lib/invoices/peppol-delivery'
 import { loadPeppolDocument } from '@/lib/invoices/peppol-document'
 import { getPeppolTransportAvailability } from '@/lib/invoices/peppol-transport'
 
@@ -83,6 +83,12 @@ export const POST = withRouteContext<{ params: Promise<{ id: string }> }>(
         },
       }, { status: 201 }))
     } catch (err) {
+      if (isFiscalPeriodMissingError(err)) {
+        return privateNoStore(errorResponseFromCode('PEPPOL_FISCAL_PERIOD_MISSING', log, {
+          requestId,
+          details: { invoice_date: loaded.invoice.invoice_date },
+        }))
+      }
       return privateNoStore(errorResponse(err, log, { requestId }))
     }
   },

--- a/app/api/invoices/[id]/peppol/send/__tests__/route.test.ts
+++ b/app/api/invoices/[id]/peppol/send/__tests__/route.test.ts
@@ -267,7 +267,14 @@ describe('POST /api/invoices/[id]/peppol/send', () => {
     realCompany(true)
     const response = await send()
     expect(response.status).toBe(403)
-    expect((await response.json()).error.code).toBe('PEPPOL_SANDBOX_NOT_ALLOWED')
+    const body = await response.json()
+    expect(body.error.code).toBe('PEPPOL_SANDBOX_NOT_ALLOWED')
+    expect(body.error.message).toBe(
+      'Peppol-sändning är inte tillgänglig i demobolaget. Skapa ett riktigt konto för att skicka e-fakturor.',
+    )
+    expect(body.error.message_en).toBe(
+      'Peppol sending is not available in the demo company. Create a real account to send e-invoices.',
+    )
     expect(transport.lookupRecipient).not.toHaveBeenCalled()
     expect(transport.submit).not.toHaveBeenCalled()
     expectRefusalLogged('PEPPOL_SANDBOX_NOT_ALLOWED')
@@ -320,6 +327,26 @@ describe('POST /api/invoices/[id]/peppol/send', () => {
     expect(response.status).toBe(409)
     expect((await response.json()).error.code).toBe('PEPPOL_SEND_INVALID_STATUS')
     expectRefusalLogged('PEPPOL_SEND_INVALID_STATUS')
+  })
+
+  it('logs which BIS preflight rule stopped the send', async () => {
+    const transport = makeTransport()
+    unregister = registerPeppolTransport(transport)
+    realCompany()
+    grantAccess()
+    enqueue({ data: invoiceRow({ your_reference: null }), error: null })
+    enqueue({ data: company, error: null })
+
+    const response = await send()
+
+    expect(response.status).toBe(400)
+    expect((await response.json()).error.code).toBe('VALIDATION_ERROR')
+    expect(transport.lookupRecipient).not.toHaveBeenCalled()
+    expect(logMock.info).toHaveBeenCalledWith('peppol send refused', {
+      invoiceId: INVOICE_ID,
+      code: 'VALIDATION_ERROR',
+      issues: ['BUYER_REFERENCE_REQUIRED'],
+    })
   })
 
   it('names the missing fiscal year when the stage RPC has no retention basis for the invoice date', async () => {
@@ -407,7 +434,7 @@ describe('POST /api/invoices/[id]/peppol/send', () => {
     expect(serviceRpcMock).not.toHaveBeenCalled()
   })
 
-  it('answers 422 with the same code when the lookup failure is not retryable', async () => {
+  it('answers 502 too when the lookup failure is not retryable: a lookup is never a document verdict', async () => {
     const transport = makeTransport({
       lookupRecipient: vi.fn().mockRejectedValue(
         connectorFailure('CONNECTOR_PROTOCOL_ERROR', false, 'participant: Required'),
@@ -420,7 +447,7 @@ describe('POST /api/invoices/[id]/peppol/send', () => {
 
     const response = await send()
 
-    expect(response.status).toBe(422)
+    expect(response.status).toBe(502)
     const body = await response.json()
     expect(body.error.code).toBe('PEPPOL_LOOKUP_FAILED')
     expect(body.error.details.code).toBe('CONNECTOR_PROTOCOL_ERROR')
@@ -603,10 +630,10 @@ describe('POST /api/invoices/[id]/peppol/send', () => {
     })
   })
 
-  it('records a retryable failure and answers 502 when the access point is unreachable', async () => {
+  it('records a retryable failure and answers 502 when the hosted service is unreachable', async () => {
     const transport = makeTransport({
       submit: vi.fn().mockRejectedValue(
-        new PeppolTransportError('Could not reach Qvalia', { retryable: true }),
+        connectorFailure('CONNECTOR_UNREACHABLE', true),
       ),
     })
     unregister = registerPeppolTransport(transport)
@@ -617,7 +644,9 @@ describe('POST /api/invoices/[id]/peppol/send', () => {
     const response = await send()
 
     expect(response.status).toBe(502)
-    expect((await response.json()).error.code).toBe('PEPPOL_SUBMISSION_FAILED')
+    const body = await response.json()
+    expect(body.error.code).toBe('PEPPOL_SUBMISSION_FAILED')
+    expect(body.error.details).toEqual({ reason: null, code: 'CONNECTOR_UNREACHABLE' })
     const last = serviceRpcMock.mock.calls.at(-1)?.[1] as Record<string, unknown>
     expect(last).toMatchObject({
       p_provider_event_code: 'submit_failed',
@@ -626,22 +655,61 @@ describe('POST /api/invoices/[id]/peppol/send', () => {
     })
   })
 
-  describe('hosted precondition answers never become a verdict on the document', () => {
+  describe('a retryable hosted answer is a plain failure, whatever its code', () => {
+    const transientCodes = [
+      'CONNECTOR_UNREACHABLE',
+      'CONNECTOR_RATE_LIMITED',
+      'CONNECTOR_LEDGER_FAILED',
+      'CONNECTOR_UPSTREAM_UNCONFIGURED',
+      'CONNECTOR_PEPPOL_REGISTRATION_IN_PROGRESS',
+      'CONNECTOR_UPSTREAM_ERROR',
+      'HTTP_429',
+      'HTTP_502',
+    ]
+
+    it.each(transientCodes)('%s retryable: 502 PEPPOL_SUBMISSION_FAILED, retryable_failure, not terminal', async (code) => {
+      const transport = makeTransport({
+        submit: vi.fn().mockRejectedValue(connectorFailure(code, true, 'busy')),
+      })
+      unregister = registerPeppolTransport(transport)
+      realCompany()
+      grantAccess()
+      stageInvoice()
+
+      const response = await send()
+      const body = await response.json()
+
+      expect(response.status).toBe(502)
+      expect(body.error.code).toBe('PEPPOL_SUBMISSION_FAILED')
+      expect(body.error.details).toEqual({ reason: 'busy', code })
+      const last = serviceRpcMock.mock.calls.at(-1)?.[1] as Record<string, unknown>
+      expect(last).toMatchObject({
+        p_provider_event_code: 'submit_failed',
+        p_normalized_status: 'retryable_failure',
+        p_is_terminal: false,
+      })
+    })
+  })
+
+  describe('a coded non-retryable hosted answer is a precondition, never a verdict on the document', () => {
     const preconditionCodes = [
       'CONNECTOR_PEPPOL_SENDER_NOT_REGISTERED',
       'CONNECTOR_PEPPOL_PARTICIPANT_NOT_ALLOWED',
       'CONNECTOR_QUOTA_EXCEEDED',
-      'CONNECTOR_RATE_LIMITED',
       'CONNECTOR_SCOPE_MISSING',
-      'CONNECTOR_UPSTREAM_UNCONFIGURED',
-      'CONNECTOR_LEDGER_FAILED',
-      'CONNECTOR_UNREACHABLE',
-      'CONNECTOR_PEPPOL_REGISTRATION_IN_PROGRESS',
-      'HTTP_502',
+      'CONNECTOR_KEY_INVALID',
+      'CONNECTOR_KEY_SUSPENDED',
+      'CONNECTOR_KEY_MISSING',
+      'CONNECTOR_COMPANY_MISSING',
+      'CONNECTOR_PATH_NOT_ALLOWED',
+      'CONNECTOR_NOT_OWNED',
+      'BAD_REQUEST',
+      'CONNECTOR_PROTOCOL_ERROR',
+      'HTTP_403',
+      'HTTP_404',
     ]
 
     it.each(preconditionCodes)('%s stays resendable: 409, retryable_failure, and the same XML is submitted again', async (code) => {
-      // Non-retryable on the wire on purpose: the code decides, not the flag.
       const transport = makeTransport({
         submit: vi.fn()
           .mockRejectedValueOnce(connectorFailure(code, false, 'hosted detail'))
@@ -681,9 +749,25 @@ describe('POST /api/invoices/[id]/peppol/send', () => {
       expect((await second.json()).data.delivery.status).toBe('submission_accepted')
     })
 
-    it('composes the hosted text onto the prefix when the registry knows the code', async () => {
+    it.each([
+      [
+        'CONNECTOR_PEPPOL_SENDER_NOT_REGISTERED',
+        'Fakturan kunde inte skickas via Peppol ännu: Bolagets Peppol-id är inte registrerat hos operatören. Slå på mottagning under Inställningar > Fakturering > E-faktura via Peppol, eller kontakta support.',
+        "The invoice could not be sent via Peppol yet: The company's Peppol id is not registered with the access point. Switch on receiving under Settings > Invoicing > E-invoicing via Peppol, or contact support.",
+      ],
+      [
+        'CONNECTOR_SCOPE_MISSING',
+        'Fakturan kunde inte skickas via Peppol ännu: Kopplingsnyckeln saknar Peppol-behörighet. Kontakta support.',
+        'The invoice could not be sent via Peppol yet: The connector key lacks Peppol permission. Contact support.',
+      ],
+      [
+        'CONNECTOR_QUOTA_EXCEEDED',
+        'Fakturan kunde inte skickas via Peppol ännu: Kontots Peppol-platser är förbrukade. Hör av dig till support så öppnar vi fler.',
+        'The invoice could not be sent via Peppol yet: The account has used its Peppol slots. Contact support and we will open more.',
+      ],
+    ])('composes the hosted text onto the prefix when the registry knows %s', async (code, sv, en) => {
       unregister = registerPeppolTransport(makeTransport({
-        submit: vi.fn().mockRejectedValue(connectorFailure('CONNECTOR_QUOTA_EXCEEDED', false)),
+        submit: vi.fn().mockRejectedValue(connectorFailure(code, false)),
       }))
       realCompany()
       grantAccess()
@@ -691,17 +775,13 @@ describe('POST /api/invoices/[id]/peppol/send', () => {
 
       const body = await (await send()).json()
 
-      expect(body.error.message).toBe(
-        'Fakturan kunde inte skickas via Peppol ännu: Kontots Peppol-platser är förbrukade. Hör av dig till support så öppnar vi fler.',
-      )
-      expect(body.error.message_en).toBe(
-        'The invoice could not be sent via Peppol yet: The account has used its Peppol slots. Contact support and we will open more.',
-      )
+      expect(body.error.message).toBe(sv)
+      expect(body.error.message_en).toBe(en)
     })
 
     it('falls back to the settings pointer for a code the registry does not know', async () => {
       unregister = registerPeppolTransport(makeTransport({
-        submit: vi.fn().mockRejectedValue(connectorFailure('HTTP_502', false)),
+        submit: vi.fn().mockRejectedValue(connectorFailure('HTTP_403', false)),
       }))
       realCompany()
       grantAccess()

--- a/app/api/invoices/[id]/peppol/send/__tests__/route.test.ts
+++ b/app/api/invoices/[id]/peppol/send/__tests__/route.test.ts
@@ -21,6 +21,18 @@ const requireAuthMock = vi.fn()
 const serviceRpcMock = vi.fn()
 const issueAndBookMock = vi.fn()
 
+/** One shared logger for the route and its wrapper, so refusal lines can be asserted. */
+const logMock = vi.hoisted(() => {
+  const log = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), child: vi.fn() }
+  log.child.mockImplementation(() => log)
+  return log
+})
+
+vi.mock('@/lib/logger', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/logger')>()),
+  createLogger: () => logMock,
+}))
+
 vi.mock('@/lib/init', () => ({
   ensureInitialized: vi.fn(),
 }))
@@ -117,6 +129,14 @@ const stagedDelivery = {
   created_at: '2026-08-21T10:00:00.000Z',
 }
 
+const acceptedReceipt = {
+  provider: 'qvalia',
+  providerSubmissionId: 'int-1',
+  idempotencyKey: IDEMPOTENCY_KEY,
+  tenantReference: 'company-1',
+  acceptedAt: '2026-08-21T10:00:02.000Z',
+}
+
 function makeTransport(overrides: Partial<PeppolTransport> = {}): PeppolTransport {
   return {
     provider: 'qvalia',
@@ -126,13 +146,7 @@ function makeTransport(overrides: Partial<PeppolTransport> = {}): PeppolTranspor
       capabilities: [],
       checkedAt: '2026-08-21T10:00:01.000Z',
     }),
-    submit: vi.fn().mockResolvedValue({
-      provider: 'qvalia',
-      providerSubmissionId: 'int-1',
-      idempotencyKey: IDEMPOTENCY_KEY,
-      tenantReference: 'company-1',
-      acceptedAt: '2026-08-21T10:00:02.000Z',
-    }),
+    submit: vi.fn().mockResolvedValue(acceptedReceipt),
     verifyWebhook: vi.fn().mockResolvedValue([]),
     retrieveEvidence: vi.fn().mockResolvedValue([]),
     ...overrides,
@@ -148,10 +162,20 @@ const accessRow = {
   enabled_at: '2026-08-21T16:00:00.000Z', enabled_by: 'jakob', disabled_at: null, note: null,
   created_at: '2026-08-21T16:00:00.000Z', updated_at: '2026-08-21T16:00:00.000Z',
 }
+/** The sandbox gate reads company_settings.is_sandbox through the user client before anything else. */
+function realCompany(isSandbox = false) {
+  enqueue({ data: { is_sandbox: isSandbox }, error: null })
+}
 /** Peppol access is per company: grant it (service reads access row, then the send count). */
 function grantAccess(maxSends: number | null = 50, sent = 0) {
   serviceTables.enqueue({ data: { ...accessRow, max_sends: maxSends }, error: null })
   serviceTables.enqueue({ data: null, error: null, count: sent })
+}
+/** The user-client reads a send makes once it is past the gates: invoice, company settings, stage RPC. */
+function stageInvoice(overrides: Partial<ReturnType<typeof makeInvoice>> = {}, delivery: Record<string, unknown> = stagedDelivery) {
+  enqueue({ data: invoiceRow(overrides), error: null })
+  enqueue({ data: company, error: null })
+  enqueue({ data: delivery, error: null })
 }
 
 /** The service-role RPC echoes the event's status back as the projection. */
@@ -168,6 +192,10 @@ function serviceRpcEcho() {
     },
     error: null,
   }))
+}
+
+function connectorFailure(code: string, retryable: boolean, detail: string | null = null) {
+  return new PeppolTransportError('Connector: hosted refusal', { retryable, code, detail })
 }
 
 describe('POST /api/invoices/[id]/peppol/send', () => {
@@ -198,6 +226,10 @@ describe('POST /api/invoices/[id]/peppol/send', () => {
     )
   }
 
+  function expectRefusalLogged(code: string) {
+    expect(logMock.info).toHaveBeenCalledWith('peppol send refused', { invoiceId: INVOICE_ID, code })
+  }
+
   it('returns 401 when the caller is not authenticated', async () => {
     unregister = registerPeppolTransport(makeTransport())
     requireAuthMock.mockResolvedValue({
@@ -226,21 +258,37 @@ describe('POST /api/invoices/[id]/peppol/send', () => {
     const body = await response.json()
     expect(body.error.code).toBe('PEPPOL_TRANSPORT_UNAVAILABLE')
     expect(body.error.details.reason).toBe('provider_selection_required')
+    expectRefusalLogged('PEPPOL_TRANSPORT_UNAVAILABLE')
+  })
+
+  it('refuses the demo company before it can reach the access point', async () => {
+    const transport = makeTransport()
+    unregister = registerPeppolTransport(transport)
+    realCompany(true)
+    const response = await send()
+    expect(response.status).toBe(403)
+    expect((await response.json()).error.code).toBe('PEPPOL_SANDBOX_NOT_ALLOWED')
+    expect(transport.lookupRecipient).not.toHaveBeenCalled()
+    expect(transport.submit).not.toHaveBeenCalled()
+    expectRefusalLogged('PEPPOL_SANDBOX_NOT_ALLOWED')
   })
 
   it('refuses a company without a Peppol grant before touching the invoice', async () => {
     const transport = makeTransport()
     unregister = registerPeppolTransport(transport)
+    realCompany()
     serviceTables.enqueue({ data: null, error: null })              // no access row
     const response = await send()
     expect(response.status).toBe(403)
     expect((await response.json()).error.code).toBe('PEPPOL_ACCESS_REQUIRED')
     expect(transport.submit).not.toHaveBeenCalled()
+    expectRefusalLogged('PEPPOL_ACCESS_REQUIRED')
   })
 
   it('refuses once the company has used its sending cap', async () => {
     const transport = makeTransport()
     unregister = registerPeppolTransport(transport)
+    realCompany()
     grantAccess(5, 5)
     const response = await send()
     expect(response.status).toBe(409)
@@ -248,25 +296,70 @@ describe('POST /api/invoices/[id]/peppol/send', () => {
     expect(body.error.code).toBe('PEPPOL_SEND_LIMIT_REACHED')
     expect(body.error.details).toMatchObject({ max_sends: 5, sent_count: 5 })
     expect(transport.submit).not.toHaveBeenCalled()
+    expectRefusalLogged('PEPPOL_SEND_LIMIT_REACHED')
   })
 
   it('returns 404 when the invoice is not in the active company', async () => {
     unregister = registerPeppolTransport(makeTransport())
+    realCompany()
     grantAccess()
     enqueue({ data: null, error: { message: 'not found' } })
     const response = await send()
     expect(response.status).toBe(404)
     expect((await response.json()).error.code).toBe('INVOICE_NOT_FOUND')
+    expectRefusalLogged('INVOICE_NOT_FOUND')
   })
 
   it('rejects cancelled and proforma invoices with a state conflict', async () => {
     unregister = registerPeppolTransport(makeTransport())
+    realCompany()
     grantAccess()
     enqueue({ data: invoiceRow({ status: 'cancelled' }), error: null })
     enqueue({ data: company, error: null })
     const response = await send()
     expect(response.status).toBe(409)
     expect((await response.json()).error.code).toBe('PEPPOL_SEND_INVALID_STATUS')
+    expectRefusalLogged('PEPPOL_SEND_INVALID_STATUS')
+  })
+
+  it('names the missing fiscal year when the stage RPC has no retention basis for the invoice date', async () => {
+    const transport = makeTransport()
+    unregister = registerPeppolTransport(transport)
+    realCompany()
+    grantAccess()
+    enqueue({ data: invoiceRow(), error: null })
+    enqueue({ data: company, error: null })
+    enqueue({
+      data: null,
+      error: { code: 'P0002', message: 'Peppol delivery requires a fiscal period retention basis' },
+    })
+
+    const response = await send()
+
+    expect(response.status).toBe(422)
+    const body = await response.json()
+    expect(body.error.code).toBe('PEPPOL_FISCAL_PERIOD_MISSING')
+    expect(body.error.details).toMatchObject({ invoice_date: '2026-08-13' })
+    expect(transport.lookupRecipient).not.toHaveBeenCalled()
+    expect(serviceRpcMock).not.toHaveBeenCalled()
+    expectRefusalLogged('PEPPOL_FISCAL_PERIOD_MISSING')
+  })
+
+  it('keeps the generic mapping for the stage RPC\'s other P0002', async () => {
+    unregister = registerPeppolTransport(makeTransport())
+    realCompany()
+    grantAccess()
+    enqueue({ data: invoiceRow(), error: null })
+    enqueue({ data: company, error: null })
+    enqueue({
+      data: null,
+      error: { code: 'P0002', message: 'invoice not found or not eligible for Peppol staging' },
+    })
+
+    const response = await send()
+
+    expect((await response.json()).error.code).not.toBe('PEPPOL_FISCAL_PERIOD_MISSING')
+    expect(logMock.info).not.toHaveBeenCalledWith('peppol send refused', expect.anything())
   })
 
   it('stops before the network when the recipient has no Peppol registration', async () => {
@@ -279,10 +372,9 @@ describe('POST /api/invoices/[id]/peppol/send', () => {
       }),
     })
     unregister = registerPeppolTransport(transport)
+    realCompany()
     grantAccess()
-    enqueue({ data: invoiceRow(), error: null })
-    enqueue({ data: company, error: null })
-    enqueue({ data: stagedDelivery, error: null })
+    stageInvoice()
 
     const response = await send()
 
@@ -294,13 +386,68 @@ describe('POST /api/invoices/[id]/peppol/send', () => {
     expect(serviceRpcMock).not.toHaveBeenCalled()
   })
 
+  it('answers 502 and records nothing terminal when the lookup itself fails transiently', async () => {
+    const transport = makeTransport({
+      lookupRecipient: vi.fn().mockRejectedValue(
+        connectorFailure('CONNECTOR_UNREACHABLE', true, 'ECONNRESET'),
+      ),
+    })
+    unregister = registerPeppolTransport(transport)
+    realCompany()
+    grantAccess()
+    stageInvoice()
+
+    const response = await send()
+
+    expect(response.status).toBe(502)
+    const body = await response.json()
+    expect(body.error.code).toBe('PEPPOL_LOOKUP_FAILED')
+    expect(body.error.details).toEqual({ reason: 'ECONNRESET', code: 'CONNECTOR_UNREACHABLE' })
+    expect(transport.submit).not.toHaveBeenCalled()
+    expect(serviceRpcMock).not.toHaveBeenCalled()
+  })
+
+  it('answers 422 with the same code when the lookup failure is not retryable', async () => {
+    const transport = makeTransport({
+      lookupRecipient: vi.fn().mockRejectedValue(
+        connectorFailure('CONNECTOR_PROTOCOL_ERROR', false, 'participant: Required'),
+      ),
+    })
+    unregister = registerPeppolTransport(transport)
+    realCompany()
+    grantAccess()
+    stageInvoice()
+
+    const response = await send()
+
+    expect(response.status).toBe(422)
+    const body = await response.json()
+    expect(body.error.code).toBe('PEPPOL_LOOKUP_FAILED')
+    expect(body.error.details.code).toBe('CONNECTOR_PROTOCOL_ERROR')
+    expect(serviceRpcMock).not.toHaveBeenCalled()
+  })
+
+  it('keeps the generic handling when the lookup throws something that is not a transport error', async () => {
+    const transport = makeTransport({
+      lookupRecipient: vi.fn().mockRejectedValue(new Error('boom')),
+    })
+    unregister = registerPeppolTransport(transport)
+    realCompany()
+    grantAccess()
+    stageInvoice()
+
+    const response = await send()
+
+    expect(response.status).toBe(500)
+    expect((await response.json()).error.code).not.toBe('PEPPOL_LOOKUP_FAILED')
+  })
+
   it('looks up, submits the staged XML and records the lifecycle for an already issued invoice', async () => {
     const transport = makeTransport()
     unregister = registerPeppolTransport(transport)
+    realCompany()
     grantAccess()
-    enqueue({ data: invoiceRow(), error: null })
-    enqueue({ data: company, error: null })
-    enqueue({ data: stagedDelivery, error: null })
+    stageInvoice()
 
     const response = await send()
     const body = await response.json()
@@ -335,15 +482,15 @@ describe('POST /api/invoices/[id]/peppol/send', () => {
       expect((call[1] as Record<string, unknown>).p_provider_tenant_id).toBe('SE5560000000')
     }
     expect(issueAndBookMock).not.toHaveBeenCalled()
+    expect(logMock.info).not.toHaveBeenCalledWith('peppol send refused', expect.anything())
   })
 
   it('issues and books a draft only after the network accepted it', async () => {
     const transport = makeTransport()
     unregister = registerPeppolTransport(transport)
+    realCompany()
     grantAccess()
-    enqueue({ data: invoiceRow({ status: 'draft' }), error: null })
-    enqueue({ data: company, error: null })
-    enqueue({ data: stagedDelivery, error: null })
+    stageInvoice({ status: 'draft' })
 
     const response = await send()
     const body = await response.json()
@@ -362,11 +509,10 @@ describe('POST /api/invoices/[id]/peppol/send', () => {
 
   it('reports a failed issuance without pretending the network send did not happen', async () => {
     unregister = registerPeppolTransport(makeTransport())
+    realCompany()
     grantAccess()
     issueAndBookMock.mockResolvedValue({ ok: false, errorCode: 'INVOICE_MARK_SENT_RACE' })
-    enqueue({ data: invoiceRow({ status: 'draft' }), error: null })
-    enqueue({ data: company, error: null })
-    enqueue({ data: stagedDelivery, error: null })
+    stageInvoice({ status: 'draft' })
 
     const response = await send()
     const body = await response.json()
@@ -382,12 +528,13 @@ describe('POST /api/invoices/[id]/peppol/send', () => {
   it('replays idempotently when the exact XML was already handed to the network', async () => {
     const transport = makeTransport()
     unregister = registerPeppolTransport(transport)
+    realCompany()
     grantAccess()
-    enqueue({ data: invoiceRow(), error: null })
-    enqueue({ data: company, error: null })
-    enqueue({
-      data: { ...stagedDelivery, provider: 'qvalia', provider_submission_id: 'int-1', status: 'submission_accepted' },
-      error: null,
+    stageInvoice({}, {
+      ...stagedDelivery,
+      provider: 'qvalia',
+      provider_submission_id: 'int-1',
+      status: 'submission_accepted',
     })
 
     const response = await send()
@@ -409,10 +556,9 @@ describe('POST /api/invoices/[id]/peppol/send', () => {
       ),
     })
     unregister = registerPeppolTransport(transport)
+    realCompany()
     grantAccess()
-    enqueue({ data: invoiceRow({ status: 'draft' }), error: null })
-    enqueue({ data: company, error: null })
-    enqueue({ data: stagedDelivery, error: null })
+    stageInvoice({ status: 'draft' })
 
     const response = await send()
     const body = await response.json()
@@ -429,6 +575,34 @@ describe('POST /api/invoices/[id]/peppol/send', () => {
     expect(issueAndBookMock).not.toHaveBeenCalled()
   })
 
+  it('still records a terminal rejection for a non-retryable CONNECTOR_UPSTREAM_ERROR (the access point refused the document)', async () => {
+    const transport = makeTransport({
+      submit: vi.fn().mockRejectedValue(
+        connectorFailure('CONNECTOR_UPSTREAM_ERROR', false, 'BR-CO-10 Sum of invoice line net amount'),
+      ),
+    })
+    unregister = registerPeppolTransport(transport)
+    realCompany()
+    grantAccess()
+    stageInvoice()
+
+    const response = await send()
+    const body = await response.json()
+
+    expect(response.status).toBe(422)
+    expect(body.error.code).toBe('PEPPOL_SUBMISSION_REJECTED')
+    expect(body.error.details).toEqual({
+      reason: 'BR-CO-10 Sum of invoice line net amount',
+      code: 'CONNECTOR_UPSTREAM_ERROR',
+    })
+    const last = serviceRpcMock.mock.calls.at(-1)?.[1] as Record<string, unknown>
+    expect(last).toMatchObject({
+      p_provider_event_code: 'submit_rejected',
+      p_normalized_status: 'failed',
+      p_is_terminal: true,
+    })
+  })
+
   it('records a retryable failure and answers 502 when the access point is unreachable', async () => {
     const transport = makeTransport({
       submit: vi.fn().mockRejectedValue(
@@ -436,10 +610,9 @@ describe('POST /api/invoices/[id]/peppol/send', () => {
       ),
     })
     unregister = registerPeppolTransport(transport)
+    realCompany()
     grantAccess()
-    enqueue({ data: invoiceRow(), error: null })
-    enqueue({ data: company, error: null })
-    enqueue({ data: stagedDelivery, error: null })
+    stageInvoice()
 
     const response = await send()
 
@@ -453,21 +626,109 @@ describe('POST /api/invoices/[id]/peppol/send', () => {
     })
   })
 
+  describe('hosted precondition answers never become a verdict on the document', () => {
+    const preconditionCodes = [
+      'CONNECTOR_PEPPOL_SENDER_NOT_REGISTERED',
+      'CONNECTOR_PEPPOL_PARTICIPANT_NOT_ALLOWED',
+      'CONNECTOR_QUOTA_EXCEEDED',
+      'CONNECTOR_RATE_LIMITED',
+      'CONNECTOR_SCOPE_MISSING',
+      'CONNECTOR_UPSTREAM_UNCONFIGURED',
+      'CONNECTOR_LEDGER_FAILED',
+      'CONNECTOR_UNREACHABLE',
+      'CONNECTOR_PEPPOL_REGISTRATION_IN_PROGRESS',
+      'HTTP_502',
+    ]
+
+    it.each(preconditionCodes)('%s stays resendable: 409, retryable_failure, and the same XML is submitted again', async (code) => {
+      // Non-retryable on the wire on purpose: the code decides, not the flag.
+      const transport = makeTransport({
+        submit: vi.fn()
+          .mockRejectedValueOnce(connectorFailure(code, false, 'hosted detail'))
+          .mockResolvedValueOnce(acceptedReceipt),
+      })
+      unregister = registerPeppolTransport(transport)
+      realCompany()
+      grantAccess()
+      stageInvoice()
+
+      const first = await send()
+      const body = await first.json()
+
+      expect(first.status).toBe(409)
+      expect(body.error.code).toBe('PEPPOL_SEND_PRECONDITION_FAILED')
+      expect(body.error.details).toEqual({ reason: 'hosted detail', code })
+      expect(body.error.message).toMatch(/^Fakturan kunde inte skickas via Peppol ännu: /)
+      const last = serviceRpcMock.mock.calls.at(-1)?.[1] as Record<string, unknown>
+      expect(last).toMatchObject({
+        p_provider_event_code: 'submit_failed',
+        p_normalized_status: 'retryable_failure',
+        p_is_terminal: false,
+      })
+      expect(serviceRpcMock.mock.calls.map((call) => (call[1] as Record<string, unknown>).p_provider_event_code))
+        .not.toContain('submit_rejected')
+
+      // Same XML again: the stage RPC hands back the non-terminal row and
+      // the route goes to the network a second time instead of refusing.
+      realCompany()
+      grantAccess()
+      stageInvoice({}, { ...stagedDelivery, status: 'retryable_failure', status_detail: 'hosted detail' })
+
+      const second = await send()
+
+      expect(second.status).toBe(201)
+      expect(transport.submit).toHaveBeenCalledTimes(2)
+      expect((await second.json()).data.delivery.status).toBe('submission_accepted')
+    })
+
+    it('composes the hosted text onto the prefix when the registry knows the code', async () => {
+      unregister = registerPeppolTransport(makeTransport({
+        submit: vi.fn().mockRejectedValue(connectorFailure('CONNECTOR_QUOTA_EXCEEDED', false)),
+      }))
+      realCompany()
+      grantAccess()
+      stageInvoice()
+
+      const body = await (await send()).json()
+
+      expect(body.error.message).toBe(
+        'Fakturan kunde inte skickas via Peppol ännu: Kontots Peppol-platser är förbrukade. Hör av dig till support så öppnar vi fler.',
+      )
+      expect(body.error.message_en).toBe(
+        'The invoice could not be sent via Peppol yet: The account has used its Peppol slots. Contact support and we will open more.',
+      )
+    })
+
+    it('falls back to the settings pointer for a code the registry does not know', async () => {
+      unregister = registerPeppolTransport(makeTransport({
+        submit: vi.fn().mockRejectedValue(connectorFailure('HTTP_502', false)),
+      }))
+      realCompany()
+      grantAccess()
+      stageInvoice()
+
+      const body = await (await send()).json()
+
+      expect(body.error.message).toBe(
+        'Fakturan kunde inte skickas via Peppol ännu: kontrollera Peppol-inställningarna och försök igen.',
+      )
+      expect(body.error.message_en).toBe(
+        'The invoice could not be sent via Peppol yet: check the Peppol settings and try again.',
+      )
+    })
+  })
+
   it('refuses to resend an exact document the access point already rejected', async () => {
     const transport = makeTransport()
     unregister = registerPeppolTransport(transport)
+    realCompany()
     grantAccess()
-    enqueue({ data: invoiceRow(), error: null })
-    enqueue({ data: company, error: null })
-    enqueue({
-      data: {
-        ...stagedDelivery,
-        provider: 'qvalia',
-        status: 'failed',
-        status_detail: 'BR-CO-10',
-        terminal_at: '2026-08-21T09:00:00.000Z',
-      },
-      error: null,
+    stageInvoice({}, {
+      ...stagedDelivery,
+      provider: 'qvalia',
+      status: 'failed',
+      status_detail: 'BR-CO-10',
+      terminal_at: '2026-08-21T09:00:00.000Z',
     })
 
     const response = await send()

--- a/app/api/invoices/[id]/peppol/send/route.ts
+++ b/app/api/invoices/[id]/peppol/send/route.ts
@@ -14,6 +14,7 @@ import {
   PEPPOL_BIS_BILLING_PROFILE_ID,
 } from '@/lib/invoices/peppol-bis-billing'
 import {
+  isFiscalPeriodMissingError,
   persistVerifiedPeppolEvent,
   sha256Hex,
   stagePeppolDelivery,
@@ -44,28 +45,23 @@ const paramsSchema = z.object({ id: z.uuid() })
 const SENDABLE_STATUSES = new Set<Invoice['status']>(['draft', 'sent', 'overdue'])
 
 /**
- * Hosted answers about the sender, the key or the service, never about the
- * document: the sender is not registered, the participant is not allowed on
- * this key, the quota or rate limit is hit, a scope is missing, the upstream
- * is unconfigured or unreachable. None of them is a verdict on the invoice,
- * so the delivery stays resendable and the event is submit_failed, whatever
- * the envelope's retryable flag says. A bare HTTP_<n> belongs here too: it
- * means the connector URL never reached a Peppol route.
+ * How a failed submission is classified. A verdict on the document arrives
+ * only as the access point's own answer: the direct adapter throws a
+ * non-retryable error without a code, and the connector wraps the access
+ * point's refusal as a non-retryable CONNECTOR_UPSTREAM_ERROR. Every other
+ * coded answer is about the sender, the key, the route or the service:
+ * transient ones (unreachable, rate limited, ledger, upstream unconfigured,
+ * HTTP 429/5xx) are a plain failure; permanent ones (sender not registered,
+ * not allowed, quota, scope, key, HTTP 4xx, protocol) are a precondition.
+ * Neither is terminal: the delivery stays resendable.
  */
-const PRECONDITION_TRANSPORT_CODES: ReadonlySet<string> = new Set([
-  'CONNECTOR_PEPPOL_SENDER_NOT_REGISTERED',
-  'CONNECTOR_PEPPOL_PARTICIPANT_NOT_ALLOWED',
-  'CONNECTOR_QUOTA_EXCEEDED',
-  'CONNECTOR_RATE_LIMITED',
-  'CONNECTOR_SCOPE_MISSING',
-  'CONNECTOR_UPSTREAM_UNCONFIGURED',
-  'CONNECTOR_LEDGER_FAILED',
-  'CONNECTOR_UNREACHABLE',
-  'CONNECTOR_PEPPOL_REGISTRATION_IN_PROGRESS',
-])
+type SubmitVerdict = 'rejected' | 'precondition' | 'failed'
 
-function isPreconditionCode(code: string | null): code is string {
-  return code !== null && (PRECONDITION_TRANSPORT_CODES.has(code) || /^HTTP_\d+$/.test(code))
+function classifySubmitFailure(err: unknown): { verdict: SubmitVerdict; code: string | null } {
+  if (!isPeppolTransportError(err)) return { verdict: 'failed', code: null }
+  if (err.retryable) return { verdict: 'failed', code: err.code }
+  const documentVerdict = err.code === null || err.code === 'CONNECTOR_UPSTREAM_ERROR'
+  return { verdict: documentVerdict ? 'rejected' : 'precondition', code: err.code }
 }
 
 const PRECONDITION_PREFIX_SV = 'Fakturan kunde inte skickas via Peppol ännu: '
@@ -83,17 +79,6 @@ function preconditionMessages(code: string): { messageSv?: string; messageEn?: s
     messageSv: PRECONDITION_PREFIX_SV + entry.message_sv,
     messageEn: PRECONDITION_PREFIX_EN + entry.message_en,
   }
-}
-
-/**
- * stage_peppol_delivery raises P0002 with this text when no fiscal period
- * covers the invoice date (the delivery row needs the period's retention
- * basis). Its other P0002 (invoice not eligible) keeps the generic mapping.
- */
-function isFiscalPeriodMissing(err: unknown): boolean {
-  if (typeof err !== 'object' || err === null) return false
-  const { code, message } = err as { code?: unknown; message?: unknown }
-  return code === 'P0002' && typeof message === 'string' && /fiscal period retention basis/i.test(message)
 }
 
 /** Provider-source lifecycle events written by this route (service role). */
@@ -169,7 +154,8 @@ export const POST = withRouteContext<{ params: Promise<{ id: string }> }>(
     // Every refusal before a delivery row exists leaves one structured line
     // with the registry code: no amounts, no names. Prod had zero deliveries
     // and no way to tell which gate stopped them (#2484).
-    const logRefusal = (code: string) => log.info('peppol send refused', { invoiceId, code })
+    const logRefusal = (code: string, extra: Record<string, unknown> = {}) =>
+      log.info('peppol send refused', { invoiceId, code, ...extra })
     const refuse = (code: string, ctx: RefusalContext = {}) => {
       logRefusal(code)
       return privateNoStore(errorResponseFromCode(code, log, { requestId, ...ctx }))
@@ -188,7 +174,10 @@ export const POST = withRouteContext<{ params: Promise<{ id: string }> }>(
     // The demo company never speaks to the access point: a transmission is
     // billed per document.
     if (await isSandboxCompany(supabase, companyId)) {
-      return refuse('PEPPOL_SANDBOX_NOT_ALLOWED')
+      return refuse('PEPPOL_SANDBOX_NOT_ALLOWED', {
+        messageSv: 'Peppol-sändning är inte tillgänglig i demobolaget. Skapa ett riktigt konto för att skicka e-fakturor.',
+        messageEn: 'Peppol sending is not available in the demo company. Create a real account to send e-invoices.',
+      })
     }
 
     // Access is granted per company by the operators and capped in sends:
@@ -250,7 +239,8 @@ export const POST = withRouteContext<{ params: Promise<{ id: string }> }>(
 
     const generated = generatePeppolDocumentOrResponse({ invoice, company, log, requestId })
     if (!generated.ok) {
-      logRefusal(generated.code)
+      // The BIS issue codes say which preflight rule stopped the send.
+      logRefusal(generated.code, generated.issues ? { issues: generated.issues.slice(0, 10) } : {})
       return generated.response
     }
     const document = generated.document
@@ -272,7 +262,7 @@ export const POST = withRouteContext<{ params: Promise<{ id: string }> }>(
           document,
         })
       } catch (err) {
-        if (isFiscalPeriodMissing(err)) {
+        if (isFiscalPeriodMissingError(err)) {
           return refuse('PEPPOL_FISCAL_PERIOD_MISSING', { details: { invoice_date: invoice.invoice_date } })
         }
         throw err
@@ -298,8 +288,9 @@ export const POST = withRouteContext<{ params: Promise<{ id: string }> }>(
       }
 
       // A lookup that cannot be performed is not a lookup that answered "not
-      // registered": the delivery stays staged and nothing terminal is
-      // recorded. Anything but a transport error keeps the generic handling.
+      // registered" and never a verdict on the document: the delivery stays
+      // staged, nothing terminal is recorded, and the answer is always 502
+      // retryable. Anything but a transport error keeps the generic handling.
       let lookup: PeppolRecipientLookup
       try {
         lookup = await transport.lookupRecipient(document.recipient)
@@ -312,7 +303,6 @@ export const POST = withRouteContext<{ params: Promise<{ id: string }> }>(
         })
         return privateNoStore(errorResponseFromCode('PEPPOL_LOOKUP_FAILED', log, {
           requestId,
-          status: err.retryable ? 502 : 422,
           details: { reason: err.detail, code: err.code },
         }))
       }
@@ -391,13 +381,11 @@ export const POST = withRouteContext<{ params: Promise<{ id: string }> }>(
         providerSubmissionId = receipt.providerSubmissionId
         acceptedAt = receipt.acceptedAt
       } catch (err) {
-        const transportCode = isPeppolTransportError(err) ? err.code : null
-        // A precondition answer is never a verdict on the document: the
-        // delivery stays resendable however the hosted side flagged it. Only
-        // a genuine rejection (provider `rejected`/`duplicate`, arriving as a
-        // non-retryable transport error) is terminal.
-        const precondition = isPreconditionCode(transportCode)
-        const retryable = precondition || (isPeppolTransportError(err) ? err.retryable : true)
+        const { verdict, code: transportCode } = classifySubmitFailure(err)
+        // Only the access point's own verdict (provider `rejected`/`duplicate`)
+        // is terminal; a precondition or a transient failure leaves the
+        // delivery resendable.
+        const retryable = verdict !== 'rejected'
         // The provider's own explanation (validation rule, duplicate notice) is
         // what the user can act on; the adapter's error message stays in the
         // event log and never reaches the response.
@@ -408,7 +396,7 @@ export const POST = withRouteContext<{ params: Promise<{ id: string }> }>(
         log.error('Peppol submission failed', err as Error, {
           invoiceId,
           retryable,
-          precondition,
+          verdict,
           transportCode,
         })
         await persistVerifiedPeppolEvent({
@@ -426,7 +414,7 @@ export const POST = withRouteContext<{ params: Promise<{ id: string }> }>(
             occurredAt: new Date().toISOString(),
           }),
         })
-        if (precondition) {
+        if (verdict === 'precondition' && transportCode !== null) {
           return privateNoStore(errorResponseFromCode('PEPPOL_SEND_PRECONDITION_FAILED', log, {
             requestId,
             ...preconditionMessages(transportCode),
@@ -434,7 +422,7 @@ export const POST = withRouteContext<{ params: Promise<{ id: string }> }>(
           }))
         }
         return privateNoStore(errorResponseFromCode(
-          retryable ? 'PEPPOL_SUBMISSION_FAILED' : 'PEPPOL_SUBMISSION_REJECTED',
+          verdict === 'failed' ? 'PEPPOL_SUBMISSION_FAILED' : 'PEPPOL_SUBMISSION_REJECTED',
           log,
           { requestId, details: { reason: providerReason, code: transportCode } },
         ))

--- a/app/api/invoices/[id]/peppol/send/route.ts
+++ b/app/api/invoices/[id]/peppol/send/route.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 import { privateNoStore } from '@/lib/api/private-no-store'
 import { withRouteContext } from '@/lib/api/with-route-context'
 import { errorResponse, errorResponseFromCode } from '@/lib/errors/get-structured-error'
+import { getErrorEntry } from '@/lib/errors/structured-errors'
 import { ensureInitialized } from '@/lib/init'
 import { ensureInvoiceNumber } from '@/lib/invoices/ensure-invoice-number'
 import { issueAndBookInvoice, type IssueAndBookResult } from '@/lib/invoices/issue-and-book-invoice'
@@ -25,9 +26,11 @@ import {
   getPeppolTransportAvailability,
   isPeppolTransportError,
   type PeppolDeliveryStatus,
+  type PeppolRecipientLookup,
   type PeppolTransport,
   type PeppolVerifiedEvent,
 } from '@/lib/invoices/peppol-transport'
+import { isSandboxCompany } from '@/lib/sandbox/guard'
 import { createServiceClient } from '@/lib/supabase/server'
 import type { Invoice } from '@/types'
 
@@ -39,6 +42,59 @@ const paramsSchema = z.object({ id: z.uuid() })
 
 /** Invoice states that may still be handed to the network. */
 const SENDABLE_STATUSES = new Set<Invoice['status']>(['draft', 'sent', 'overdue'])
+
+/**
+ * Hosted answers about the sender, the key or the service, never about the
+ * document: the sender is not registered, the participant is not allowed on
+ * this key, the quota or rate limit is hit, a scope is missing, the upstream
+ * is unconfigured or unreachable. None of them is a verdict on the invoice,
+ * so the delivery stays resendable and the event is submit_failed, whatever
+ * the envelope's retryable flag says. A bare HTTP_<n> belongs here too: it
+ * means the connector URL never reached a Peppol route.
+ */
+const PRECONDITION_TRANSPORT_CODES: ReadonlySet<string> = new Set([
+  'CONNECTOR_PEPPOL_SENDER_NOT_REGISTERED',
+  'CONNECTOR_PEPPOL_PARTICIPANT_NOT_ALLOWED',
+  'CONNECTOR_QUOTA_EXCEEDED',
+  'CONNECTOR_RATE_LIMITED',
+  'CONNECTOR_SCOPE_MISSING',
+  'CONNECTOR_UPSTREAM_UNCONFIGURED',
+  'CONNECTOR_LEDGER_FAILED',
+  'CONNECTOR_UNREACHABLE',
+  'CONNECTOR_PEPPOL_REGISTRATION_IN_PROGRESS',
+])
+
+function isPreconditionCode(code: string | null): code is string {
+  return code !== null && (PRECONDITION_TRANSPORT_CODES.has(code) || /^HTTP_\d+$/.test(code))
+}
+
+const PRECONDITION_PREFIX_SV = 'Fakturan kunde inte skickas via Peppol ännu: '
+const PRECONDITION_PREFIX_EN = 'The invoice could not be sent via Peppol yet: '
+
+/**
+ * The hosted text behind the precondition prefix when the registry knows the
+ * code; an empty override otherwise, so the registry's generic pointer to the
+ * settings stands.
+ */
+function preconditionMessages(code: string): { messageSv?: string; messageEn?: string } {
+  const entry = getErrorEntry(code)
+  if (!entry) return {}
+  return {
+    messageSv: PRECONDITION_PREFIX_SV + entry.message_sv,
+    messageEn: PRECONDITION_PREFIX_EN + entry.message_en,
+  }
+}
+
+/**
+ * stage_peppol_delivery raises P0002 with this text when no fiscal period
+ * covers the invoice date (the delivery row needs the period's retention
+ * basis). Its other P0002 (invoice not eligible) keeps the generic mapping.
+ */
+function isFiscalPeriodMissing(err: unknown): boolean {
+  if (typeof err !== 'object' || err === null) return false
+  const { code, message } = err as { code?: unknown; message?: unknown }
+  return code === 'P0002' && typeof message === 'string' && /fiscal period retention basis/i.test(message)
+}
 
 /** Provider-source lifecycle events written by this route (service role). */
 function routeEvent(args: {
@@ -91,6 +147,13 @@ function summaryPayload(delivery: PeppolDeliverySummary) {
 
 const TERMINAL_FAILURE_STATUSES = new Set(['failed', 'no_route', 'business_rejected'])
 
+interface RefusalContext {
+  details?: unknown
+  status?: number
+  messageSv?: string
+  messageEn?: string
+}
+
 export const POST = withRouteContext<{ params: Promise<{ id: string }> }>(
   'invoice.peppol.send',
   async (_request, { supabase, companyId, user, log, requestId }, { params }) => {
@@ -103,15 +166,29 @@ export const POST = withRouteContext<{ params: Promise<{ id: string }> }>(
     }
     const invoiceId = parsedParams.data.id
 
+    // Every refusal before a delivery row exists leaves one structured line
+    // with the registry code: no amounts, no names. Prod had zero deliveries
+    // and no way to tell which gate stopped them (#2484).
+    const logRefusal = (code: string) => log.info('peppol send refused', { invoiceId, code })
+    const refuse = (code: string, ctx: RefusalContext = {}) => {
+      logRefusal(code)
+      return privateNoStore(errorResponseFromCode(code, log, { requestId, ...ctx }))
+    }
+
     const availability = getPeppolTransportAvailability()
     const transport: PeppolTransport | null = availability.available
       ? getPeppolTransport(availability.provider)
       : null
     if (!availability.available || !transport) {
-      return privateNoStore(errorResponseFromCode('PEPPOL_TRANSPORT_UNAVAILABLE', log, {
-        requestId,
+      return refuse('PEPPOL_TRANSPORT_UNAVAILABLE', {
         details: { reason: availability.available ? 'provider_adapter_unavailable' : availability.reason },
-      }))
+      })
+    }
+
+    // The demo company never speaks to the access point: a transmission is
+    // billed per document.
+    if (await isSandboxCompany(supabase, companyId)) {
+      return refuse('PEPPOL_SANDBOX_NOT_ALLOWED')
     }
 
     // Access is granted per company by the operators and capped in sends:
@@ -119,18 +196,20 @@ export const POST = withRouteContext<{ params: Promise<{ id: string }> }>(
     const service = createServiceClient()
     const permission = await checkPeppolSendPermission({ service, companyId })
     if (!permission.ok) {
-      return privateNoStore(errorResponseFromCode(permission.code, log, {
-        requestId,
+      return refuse(permission.code, {
         details: {
           access_status: permission.summary.status,
           max_sends: permission.summary.max_sends,
           sent_count: permission.summary.sent_count,
         },
-      }))
+      })
     }
 
     const records = await loadPeppolRecords({ supabase, companyId, invoiceId, log, requestId })
-    if (!records.ok) return records.response
+    if (!records.ok) {
+      logRefusal(records.code)
+      return records.response
+    }
     const { invoice, company } = records
 
     const isRealInvoice = !invoice.document_type || invoice.document_type === 'invoice'
@@ -140,10 +219,9 @@ export const POST = withRouteContext<{ params: Promise<{ id: string }> }>(
       || invoice.is_self_billed
       || !SENDABLE_STATUSES.has(invoice.status)
     ) {
-      return privateNoStore(errorResponseFromCode('PEPPOL_SEND_INVALID_STATUS', log, {
-        requestId,
+      return refuse('PEPPOL_SEND_INVALID_STATUS', {
         details: { status: invoice.status, document_type: invoice.document_type ?? 'invoice' },
-      }))
+      })
     }
 
     const wasDraft = invoice.status === 'draft'
@@ -153,18 +231,12 @@ export const POST = withRouteContext<{ params: Promise<{ id: string }> }>(
     if (wasDraft) {
       const payeeSnapshot = await snapshotInvoicePayee(supabase, companyId, invoice)
       if (!payeeSnapshot.ok) {
-        return privateNoStore(errorResponseFromCode(payeeSnapshot.code, log, {
-          requestId,
-          details: payeeSnapshot.details,
-        }))
+        return refuse(payeeSnapshot.code, { details: payeeSnapshot.details })
       }
       invoice.payment_details = payeeSnapshot.payee
     }
     if (wasDraft && !hasRequiredInvoicePaymentAccount(company, invoice)) {
-      return privateNoStore(errorResponseFromCode('INVOICE_SEND_PAYMENT_ACCOUNT_MISSING', log, {
-        requestId,
-        details: { currency: invoice.currency },
-      }))
+      return refuse('INVOICE_SEND_PAYMENT_ACCOUNT_MISSING', { details: { currency: invoice.currency } })
     }
 
     if (wasDraft && !invoice.invoice_number) {
@@ -172,12 +244,15 @@ export const POST = withRouteContext<{ params: Promise<{ id: string }> }>(
         invoice.invoice_number = await ensureInvoiceNumber(supabase, companyId, invoice)
       } catch (err) {
         log.error('failed to assign invoice number before Peppol send', err as Error)
-        return privateNoStore(errorResponseFromCode('INVOICE_CREATE_NUMBER_ASSIGN_FAILED', log, { requestId }))
+        return refuse('INVOICE_CREATE_NUMBER_ASSIGN_FAILED')
       }
     }
 
     const generated = generatePeppolDocumentOrResponse({ invoice, company, log, requestId })
-    if (!generated.ok) return generated.response
+    if (!generated.ok) {
+      logRefusal(generated.code)
+      return generated.response
+    }
     const document = generated.document
 
     const provider = transport.provider
@@ -188,12 +263,20 @@ export const POST = withRouteContext<{ params: Promise<{ id: string }> }>(
       || provider
 
     try {
-      let delivery: PeppolDeliverySummary = await stagePeppolDelivery({
-        supabase,
-        companyId,
-        invoiceId,
-        document,
-      })
+      let delivery: PeppolDeliverySummary
+      try {
+        delivery = await stagePeppolDelivery({
+          supabase,
+          companyId,
+          invoiceId,
+          document,
+        })
+      } catch (err) {
+        if (isFiscalPeriodMissing(err)) {
+          return refuse('PEPPOL_FISCAL_PERIOD_MISSING', { details: { invoice_date: invoice.invoice_date } })
+        }
+        throw err
+      }
 
       if (delivery.provider_submission_id) {
         // Exact XML already handed to the network: idempotent replay, never a
@@ -214,7 +297,25 @@ export const POST = withRouteContext<{ params: Promise<{ id: string }> }>(
         }))
       }
 
-      const lookup = await transport.lookupRecipient(document.recipient)
+      // A lookup that cannot be performed is not a lookup that answered "not
+      // registered": the delivery stays staged and nothing terminal is
+      // recorded. Anything but a transport error keeps the generic handling.
+      let lookup: PeppolRecipientLookup
+      try {
+        lookup = await transport.lookupRecipient(document.recipient)
+      } catch (err) {
+        if (!isPeppolTransportError(err)) throw err
+        log.error('Peppol recipient lookup failed', err, {
+          invoiceId,
+          retryable: err.retryable,
+          transportCode: err.code,
+        })
+        return privateNoStore(errorResponseFromCode('PEPPOL_LOOKUP_FAILED', log, {
+          requestId,
+          status: err.retryable ? 502 : 422,
+          details: { reason: err.detail, code: err.code },
+        }))
+      }
       if (!lookup.reachable) {
         return privateNoStore(errorResponseFromCode('PEPPOL_RECIPIENT_NOT_REACHABLE', log, {
           requestId,
@@ -290,7 +391,13 @@ export const POST = withRouteContext<{ params: Promise<{ id: string }> }>(
         providerSubmissionId = receipt.providerSubmissionId
         acceptedAt = receipt.acceptedAt
       } catch (err) {
-        const retryable = isPeppolTransportError(err) ? err.retryable : true
+        const transportCode = isPeppolTransportError(err) ? err.code : null
+        // A precondition answer is never a verdict on the document: the
+        // delivery stays resendable however the hosted side flagged it. Only
+        // a genuine rejection (provider `rejected`/`duplicate`, arriving as a
+        // non-retryable transport error) is terminal.
+        const precondition = isPreconditionCode(transportCode)
+        const retryable = precondition || (isPeppolTransportError(err) ? err.retryable : true)
         // The provider's own explanation (validation rule, duplicate notice) is
         // what the user can act on; the adapter's error message stays in the
         // event log and never reaches the response.
@@ -301,6 +408,8 @@ export const POST = withRouteContext<{ params: Promise<{ id: string }> }>(
         log.error('Peppol submission failed', err as Error, {
           invoiceId,
           retryable,
+          precondition,
+          transportCode,
         })
         await persistVerifiedPeppolEvent({
           supabase: service,
@@ -317,10 +426,17 @@ export const POST = withRouteContext<{ params: Promise<{ id: string }> }>(
             occurredAt: new Date().toISOString(),
           }),
         })
+        if (precondition) {
+          return privateNoStore(errorResponseFromCode('PEPPOL_SEND_PRECONDITION_FAILED', log, {
+            requestId,
+            ...preconditionMessages(transportCode),
+            details: { reason: providerReason, code: transportCode },
+          }))
+        }
         return privateNoStore(errorResponseFromCode(
           retryable ? 'PEPPOL_SUBMISSION_FAILED' : 'PEPPOL_SUBMISSION_REJECTED',
           log,
-          { requestId, details: { reason: providerReason } },
+          { requestId, details: { reason: providerReason, code: transportCode } },
         ))
       }
 

--- a/lib/errors/structured-errors.ts
+++ b/lib/errors/structured-errors.ts
@@ -1847,6 +1847,18 @@ const INVOICE: Record<string, StructuredErrorEntry> = {
     message_sv: 'Peppol-id:t får inte registreras från det här kontot. Kontakta support.',
     message_en: 'The Peppol id may not be registered from this account. Contact support.',
   },
+  // The two likeliest send preconditions (#2484): the route composes these
+  // behind PEPPOL_SEND_PRECONDITION_FAILED's prefix.
+  CONNECTOR_PEPPOL_SENDER_NOT_REGISTERED: {
+    httpStatus: 422,
+    message_sv: 'Bolagets Peppol-id är inte registrerat hos operatören. Slå på mottagning under Inställningar > Fakturering > E-faktura via Peppol, eller kontakta support.',
+    message_en: 'The company\'s Peppol id is not registered with the access point. Switch on receiving under Settings > Invoicing > E-invoicing via Peppol, or contact support.',
+  },
+  CONNECTOR_SCOPE_MISSING: {
+    httpStatus: 403,
+    message_sv: 'Kopplingsnyckeln saknar Peppol-behörighet. Kontakta support.',
+    message_en: 'The connector key lacks Peppol permission. Contact support.',
+  },
   CONNECTOR_PEPPOL_PARTICIPANT_PUBLISHED_ELSEWHERE: {
     httpStatus: 409,
     message_sv: 'Peppol-id:t är redan publicerat hos en annan operatör. Avregistrera det där först.',

--- a/lib/errors/structured-errors.ts
+++ b/lib/errors/structured-errors.ts
@@ -1733,6 +1733,35 @@ const INVOICE: Record<string, StructuredErrorEntry> = {
     message_sv: 'Peppol-operatören kunde inte nås just nu. Fakturan har inte skickats; försök igen om en stund.',
     message_en: 'The Peppol access point could not be reached. The invoice has not been sent; try again shortly.',
   },
+  // The SMP lookup itself failed (#2484), as opposed to a lookup that
+  // answered "not registered": the staged delivery stays staged and nothing
+  // terminal is recorded. The route answers 502 when the transport says the
+  // failure is retryable, 422 otherwise.
+  PEPPOL_LOOKUP_FAILED: {
+    httpStatus: 502,
+    message_sv: 'Kunde inte slå upp mottagaren i Peppol-nätverket. Försök igen om en stund.',
+    message_en: 'Could not look up the recipient in the Peppol network. Try again shortly.',
+    retryable: true,
+  },
+  // The hosted service refused the submission for a reason about the sender,
+  // the key or the service (not registered, quota, rate limit, scope,
+  // upstream unconfigured), never about the document (#2484). The delivery
+  // stays resendable; the route composes the hosted text onto the prefix
+  // when the registry knows the code, else this generic pointer.
+  PEPPOL_SEND_PRECONDITION_FAILED: {
+    httpStatus: 409,
+    message_sv: 'Fakturan kunde inte skickas via Peppol ännu: kontrollera Peppol-inställningarna och försök igen.',
+    message_en: 'The invoice could not be sent via Peppol yet: check the Peppol settings and try again.',
+    thrown_message_sv: true,
+  },
+  // stage_peppol_delivery raises P0002 when no fiscal period covers the
+  // invoice date: the delivery row carries a retention basis (BFL 7 kap.)
+  // derived from the period, so it cannot be staged without one.
+  PEPPOL_FISCAL_PERIOD_MISSING: {
+    httpStatus: 422,
+    message_sv: 'Fakturadatumet saknar ett räkenskapsår. Skapa räkenskapsåret innan fakturan skickas via Peppol.',
+    message_en: 'The invoice date falls outside every fiscal year. Create the fiscal year before sending the invoice via Peppol.',
+  },
   // /api/settings/peppol: publishing a company's identifier for receiving.
   PEPPOL_RECEIVING_UNSUPPORTED: {
     httpStatus: 503,

--- a/lib/invoices/peppol-delivery.ts
+++ b/lib/invoices/peppol-delivery.ts
@@ -42,6 +42,19 @@ export function sha256Hex(value: string | Uint8Array): string {
   return createHash('sha256').update(value).digest('hex')
 }
 
+/**
+ * stage_peppol_delivery raises P0002 with this text when no fiscal period
+ * covers the invoice date: the delivery row carries the period's retention
+ * basis (BFL 7 kap.) and cannot exist without one. The match is on the RPC's
+ * free text, so it lives here once for every route that stages. Its other
+ * P0002 (invoice not eligible) is left to the generic mapping.
+ */
+export function isFiscalPeriodMissingError(err: unknown): boolean {
+  if (typeof err !== 'object' || err === null) return false
+  const { code, message } = err as { code?: unknown; message?: unknown }
+  return code === 'P0002' && typeof message === 'string' && /fiscal period retention basis/i.test(message)
+}
+
 export async function stagePeppolDelivery(args: {
   supabase: SupabaseClient
   companyId: string

--- a/lib/invoices/peppol-document.ts
+++ b/lib/invoices/peppol-document.ts
@@ -14,8 +14,12 @@ export type PeppolInvoiceRecord = Invoice & { customer?: Customer | null; items?
 
 type RouteLog = Parameters<typeof errorResponseFromCode>[1]
 
-/** The registry code the built response carries, so a caller can log the refusal without reading the body. */
-type RefusedPeppolResult = { ok: false; code: string; response: NextResponse }
+/**
+ * The registry code the built response carries (and, for a failed BIS
+ * preflight, the issue codes), so a caller can log the refusal without
+ * reading the body.
+ */
+type RefusedPeppolResult = { ok: false; code: string; issues?: string[]; response: NextResponse }
 
 export type LoadPeppolRecordsResult =
   | { ok: true; invoice: PeppolInvoiceRecord; company: CompanySettings }
@@ -119,6 +123,7 @@ export function generatePeppolDocumentOrResponse(args: {
     return {
       ok: false,
       code: 'VALIDATION_ERROR',
+      issues: document.issues.map((item) => item.code),
       response: privateNoStore(errorResponseFromCode('VALIDATION_ERROR', args.log, {
         requestId: args.requestId,
         messageSv: first?.messageSv,

--- a/lib/invoices/peppol-document.ts
+++ b/lib/invoices/peppol-document.ts
@@ -14,13 +14,16 @@ export type PeppolInvoiceRecord = Invoice & { customer?: Customer | null; items?
 
 type RouteLog = Parameters<typeof errorResponseFromCode>[1]
 
+/** The registry code the built response carries, so a caller can log the refusal without reading the body. */
+type RefusedPeppolResult = { ok: false; code: string; response: NextResponse }
+
 export type LoadPeppolRecordsResult =
   | { ok: true; invoice: PeppolInvoiceRecord; company: CompanySettings }
-  | { ok: false; response: NextResponse }
+  | RefusedPeppolResult
 
 export type LoadPeppolDocumentResult =
   | { ok: true; document: GeneratedPeppolInvoice; invoice: PeppolInvoiceRecord; company: CompanySettings }
-  | { ok: false; response: NextResponse }
+  | RefusedPeppolResult
 
 /**
  * Fetch the invoice (with customer and lines) and the company settings the
@@ -48,6 +51,7 @@ export async function loadPeppolRecords(args: {
   if (invoiceError || !invoice) {
     return {
       ok: false,
+      code: 'INVOICE_NOT_FOUND',
       response: privateNoStore(errorResponseFromCode(
         'INVOICE_NOT_FOUND',
         args.log,
@@ -65,6 +69,7 @@ export async function loadPeppolRecords(args: {
   if (companyError || !company) {
     return {
       ok: false,
+      code: 'INVOICE_SEND_COMPANY_SETTINGS_MISSING',
       response: privateNoStore(errorResponseFromCode(
         'INVOICE_SEND_COMPANY_SETTINGS_MISSING',
         args.log,
@@ -89,10 +94,11 @@ export function generatePeppolDocumentOrResponse(args: {
   company: CompanySettings
   log: RouteLog
   requestId: string
-}): { ok: true; document: GeneratedPeppolInvoice } | { ok: false; response: NextResponse } {
+}): { ok: true; document: GeneratedPeppolInvoice } | RefusedPeppolResult {
   if (!args.invoice.customer) {
     return {
       ok: false,
+      code: 'VALIDATION_ERROR',
       response: privateNoStore(errorResponseFromCode('VALIDATION_ERROR', args.log, {
         requestId: args.requestId,
         messageSv: 'Fakturan saknar en kund som kan användas för Peppol-export.',
@@ -112,6 +118,7 @@ export function generatePeppolDocumentOrResponse(args: {
     const first = document.issues[0]
     return {
       ok: false,
+      code: 'VALIDATION_ERROR',
       response: privateNoStore(errorResponseFromCode('VALIDATION_ERROR', args.log, {
         requestId: args.requestId,
         messageSv: first?.messageSv,


### PR DESCRIPTION
## What

The Peppol send route recorded every non-retryable transport error as a permanent document rejection (the same XML refused forever), ran the recipient lookup outside the handled block (an outage became "Ett oväntat serverfel"), logged none of its early returns, and mapped the stage RPC's missing-fiscal-year error to a generic status.

- Verdict rule: a submit failure is a document rejection (terminal, `PEPPOL_SUBMISSION_REJECTED`) only when the access point itself refused it (non-retryable `CONNECTOR_UPSTREAM_ERROR`, or a direct adapter error with no code). Every other coded hosted answer keeps the delivery resendable: retryable ones (unreachable, rate limited, ledger, unconfigured, in progress, HTTP 429/5xx) answer `PEPPOL_SUBMISSION_FAILED` 502 as before; non-retryable preconditions (sender not registered, not allowed, quota, scope, key invalid/suspended/missing, company/path/not-owned, bad request, protocol, HTTP 4xx) answer a new `PEPPOL_SEND_PRECONDITION_FAILED` 409 with the hosted registry text prefixed in Swedish and English.
- Recipient lookup wrapped: a transport failure answers `PEPPOL_LOOKUP_FAILED` 502, records nothing on the staged delivery.
- Every pre-delivery refusal logs `peppol send refused { invoiceId, code }` (BIS gate includes the issue codes); sandbox companies are refused before any write with send-worded copy; the stage RPC's missing-fiscal-year error maps to `PEPPOL_FISCAL_PERIOD_MISSING` 422 in both the send and the stage route through one shared matcher.
- Registry texts for `CONNECTOR_PEPPOL_SENDER_NOT_REGISTERED` and `CONNECTOR_SCOPE_MISSING`.

## Why (first principles)

1. Why it occurred: retryability was the only signal the route had, so "not retryable" was read as "the document was rejected"; the lookup predated the handled block.
2. What was removed: the implicit "non-retryable means rejected" rule and the hand-picked allowlist a first draft used; the rule is now a two-line predicate on the code the transport already carries.
3. Alternative considered: mapping precondition codes to retryable on the hosted side. Rejected: the instance must not depend on the flag semantics of a service it does not own; the code is the stable contract.

A resend after a protocol error (hosted 2xx with an unreadable receipt) relies on the access point's duplicate detection for the same document id rather than on local state.

## Migrations

None.

## Tests

Send route: 401/400/404/happy as before plus sandbox, P0002 both variants, lookup transient/permanent/non-transport, it.each over 8 retryable and 14 non-retryable coded answers (second POST submits again), composed and fallback texts, non-retryable upstream error still terminal, refusal logs on seven paths; stage route P0002. Skeptic: two passes on 8a15e0de8; all findings fixed in 4956982b8.

Fixes #2484

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QspVe6ETYvX9SDVPPyu51M


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Peppol submissions now provide clearer, structured errors for missing fiscal-period retention information, including the invoice date.
  - Submission failures are classified more accurately, distinguishing retryable connector issues from precondition failures.
  - Recipient lookup transport errors now return a retryable response instead of a generic failure.
  - Peppol sending is refused for sandbox/demo companies with an appropriate error message.
  - Swedish and English messages are now provided for applicable submission precondition failures.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->