### PR TITLE
fix(accounts): Kontoplan can add 21xx (untaxed reserves) accounts

### DIFF
--- a/app/api/bookkeeping/accounts/__tests__/accounts.test.ts
+++ b/app/api/bookkeeping/accounts/__tests__/accounts.test.ts
@@ -311,6 +311,62 @@ describe('POST /api/bookkeeping/accounts', () => {
     expect(insertArg.default_vat_rate).toBe(0.25)
   })
 
+  it('creates a 21xx account as untaxed_reserves (#2514)', async () => {
+    // The Kontoplan dialog derives untaxed_reserves for every 21xx number;
+    // the schema used to refuse it, so no 21xx account could be added.
+    const { supabase, calls } = createCapturingSupabase([{ data: { account_number: '2129' } }])
+    auth(supabase)
+    const req = createMockRequest('/api/bookkeeping/accounts', {
+      method: 'POST',
+      body: {
+        account_number: '2129',
+        account_name: 'Periodiseringsfond 2029',
+        account_type: 'untaxed_reserves',
+        normal_balance: 'credit',
+      },
+    })
+    expect((await createPOST(req, routeParams)).status).toBe(200)
+    const insertArg = calls.find((c) => c.method === 'insert')?.args[0] as {
+      account_type?: string
+      account_class?: number
+    }
+    expect(insertArg).toMatchObject({ account_type: 'untaxed_reserves', account_class: 2 })
+  })
+
+  it('refuses an account_type that contradicts the account class, without inserting', async () => {
+    const { supabase, calls } = createCapturingSupabase([])
+    auth(supabase)
+    const req = createMockRequest('/api/bookkeeping/accounts', {
+      method: 'POST',
+      body: {
+        account_number: '2999',
+        account_name: 'Fel typ',
+        account_type: 'expense',
+        normal_balance: 'debit',
+      },
+    })
+    const { status, body } = await parseJsonResponse<{ error: string }>(await createPOST(req, routeParams))
+    expect(status).toBe(400)
+    expect(body.error).toMatch(/Kontotypen/)
+    expect(calls.some((c) => c.method === 'insert')).toBe(false)
+  })
+
+  it('refuses untaxed_reserves outside class 2', async () => {
+    const { supabase, calls } = createCapturingSupabase([])
+    auth(supabase)
+    const req = createMockRequest('/api/bookkeeping/accounts', {
+      method: 'POST',
+      body: {
+        account_number: '5999',
+        account_name: 'Fel typ',
+        account_type: 'untaxed_reserves',
+        normal_balance: 'credit',
+      },
+    })
+    expect((await createPOST(req, routeParams)).status).toBe(400)
+    expect(calls.some((c) => c.method === 'insert')).toBe(false)
+  })
+
   it('rejects a treatment that cannot apply to the account class', async () => {
     const { supabase } = createCapturingSupabase([])
     auth(supabase)

--- a/app/api/bookkeeping/accounts/route.ts
+++ b/app/api/bookkeeping/accounts/route.ts
@@ -6,6 +6,7 @@ import { validateBody, validateQuery } from '@/lib/api/validate'
 import { CreateAccountSchema } from '@/lib/api/schemas'
 import { getErrorMessage as getUserErrorMessage } from '@/lib/errors/get-error-message'
 import { errorResponseFromCode } from '@/lib/errors/get-structured-error'
+import { accountClassTypeConflict } from '@/lib/pending-operations/schemas/account'
 import {
   defaultRateForVatTreatment,
   isVatTreatmentAllowedForAccountClass,
@@ -92,6 +93,15 @@ export const POST = withRouteContext(
     if (!validation.success) return validation.response
     const body = validation.data
     const accountClass = parseInt(body.account_number[0])
+    // Same class/type rule the MCP create path enforces: account_class is
+    // derived from the first digit below, so a contradicting type (2999 +
+    // expense) would put the account on the wrong side of every report.
+    if (accountClassTypeConflict(body.account_number, body.account_type)) {
+      return NextResponse.json(
+        { error: 'Kontotypen passar inte kontoklassen för det här kontonumret.' },
+        { status: 400 },
+      )
+    }
     if (
       body.default_vat_treatment &&
       !isVatTreatmentAllowedForAccountClass(body.default_vat_treatment, accountClass)

--- a/lib/api/schemas.ts
+++ b/lib/api/schemas.ts
@@ -310,8 +310,11 @@ export const VoucherSequenceNextQuerySchema = z.object({
   date: isoDate.optional(),
 })
 
+// Mirrors chart_of_accounts_account_type_check. untaxed_reserves is the 21xx
+// group (obeskattade reserver); without it every 21xx account the Kontoplan
+// dialog derived was refused (#2514).
 export const AccountTypeSchema = z.enum([
-  'asset', 'equity', 'liability', 'revenue', 'expense',
+  'asset', 'equity', 'liability', 'untaxed_reserves', 'revenue', 'expense',
 ])
 
 export const NormalBalanceSchema = z.enum(['debit', 'credit'])

--- a/lib/pending-operations/schemas/__tests__/account.test.ts
+++ b/lib/pending-operations/schemas/__tests__/account.test.ts
@@ -1,0 +1,55 @@
+/**
+ * The class/type rule both account write paths apply (the Kontoplan create
+ * route and the MCP create_account staging + commit). account_class is
+ * derived from the first digit, so a type that contradicts the number would
+ * put the account on the wrong side of the balance sheet / income statement.
+ */
+import { describe, expect, it } from 'vitest'
+import { accountClassTypeConflict, CreateAccountParamsSchema } from '../account'
+
+describe('accountClassTypeConflict', () => {
+  it('accepts the types each BAS class holds', () => {
+    expect(accountClassTypeConflict('1930', 'asset')).toBeNull()
+    expect(accountClassTypeConflict('2081', 'equity')).toBeNull()
+    expect(accountClassTypeConflict('2440', 'liability')).toBeNull()
+    expect(accountClassTypeConflict('3001', 'revenue')).toBeNull()
+    expect(accountClassTypeConflict('6570', 'expense')).toBeNull()
+    expect(accountClassTypeConflict('8310', 'revenue')).toBeNull()
+    expect(accountClassTypeConflict('8410', 'expense')).toBeNull()
+  })
+
+  it('keeps untaxed_reserves to the 21xx group (obeskattade reserver)', () => {
+    expect(accountClassTypeConflict('2110', 'untaxed_reserves')).toBeNull()
+    expect(accountClassTypeConflict('2129', 'untaxed_reserves')).toBeNull()
+    expect(accountClassTypeConflict('2150', 'untaxed_reserves')).toBeNull()
+    expect(accountClassTypeConflict('2440', 'untaxed_reserves')).toMatch(/21xx/)
+    expect(accountClassTypeConflict('2099', 'untaxed_reserves')).toMatch(/21xx/)
+    expect(accountClassTypeConflict('5999', 'untaxed_reserves')).toMatch(/21xx/)
+  })
+
+  it('refuses a type the class cannot hold', () => {
+    expect(accountClassTypeConflict('2999', 'expense')).toMatch(/class 2/)
+    expect(accountClassTypeConflict('1930', 'liability')).toMatch(/class 1/)
+    expect(accountClassTypeConflict('3001', 'expense')).toMatch(/class 3/)
+  })
+
+  it('leaves the free-use classes 0 and 9 unconstrained', () => {
+    expect(accountClassTypeConflict('9100', 'expense')).toBeNull()
+    expect(accountClassTypeConflict('0100', 'asset')).toBeNull()
+  })
+})
+
+describe('CreateAccountParamsSchema', () => {
+  const base = { account_name: 'Konto', normal_balance: 'credit' as const }
+
+  it('commits a 21xx untaxed_reserves account', () => {
+    expect(
+      CreateAccountParamsSchema.safeParse({ ...base, account_number: '2129', account_type: 'untaxed_reserves' }).success,
+    ).toBe(true)
+  })
+
+  it('refuses untaxed_reserves outside 21xx at the commit boundary', () => {
+    const r = CreateAccountParamsSchema.safeParse({ ...base, account_number: '2440', account_type: 'untaxed_reserves' })
+    expect(r.success).toBe(false)
+  })
+})

--- a/lib/pending-operations/schemas/account.ts
+++ b/lib/pending-operations/schemas/account.ts
@@ -75,6 +75,13 @@ export function accountClassTypeConflict(
   accountNumber: string,
   accountType: string,
 ): string | null {
+  // Obeskattade reserver are the 21xx group only: every BAS 2026 account of
+  // that type is 21xx (periodiseringsfonder 211x-213x, överavskrivningar
+  // 215x, ...), and so is every such row in prod. Elsewhere in class 2 the
+  // type would move a plain liability or equity row into that section.
+  if (accountType === 'untaxed_reserves' && !accountNumber.startsWith('21')) {
+    return `Account ${accountNumber} is outside the 21xx group, the only one that can hold account_type 'untaxed_reserves'.`
+  }
   const allowed = BAS_CLASS_ACCOUNT_TYPES[accountNumber[0]]
   if (!allowed || allowed.includes(accountType)) return null
   return `Account ${accountNumber} is in BAS class ${accountNumber[0]}, which cannot hold account_type '${accountType}' (allowed: ${allowed.join(', ')}).`


### PR DESCRIPTION
## Summary

Closes #2514. Adding any 21xx account through **Kontoplan > Lägg till konto** failed with a 400:

- `AddAccountDialog` derives `account_type` with `classifyAccountClient`, which returns `untaxed_reserves` for every 21xx number (checked 2110, 2129, 2150).
- `POST /api/bookkeeping/accounts` validated with `CreateAccountSchema`, whose `AccountTypeSchema` lacked `untaxed_reserves`. The database check (`20260226120553`) and the MCP create path both allow it, and 8,603 prod rows carry it.

Changes:
- `AccountTypeSchema` now includes `untaxed_reserves`. `CreateAccountSchema` is its only user.
- The create route applies the MCP path's class/type rule (`accountClassTypeConflict`) and refuses a contradicting pair with a Swedish 400 before inserting. `account_class` is derived from the first digit, so a pair like 2999 + `expense` would otherwise land on the wrong side of every report.

## First principles

Why did it happen? The account-type enum existed three times (DB check, MCP params schema, dashboard `AccountTypeSchema`), and only the dashboard copy missed the 2026-02 `untaxed_reserves` addition. The class/type guard likewise existed on one write path only. Both write paths now apply the same enum and the same guard. A single shared account-type source across all three would be a separate refactor.

## Test plan

- [x] New route tests: 21xx + `untaxed_reserves` inserts with `account_class` 2; 2999 + `expense` returns 400 without inserting; 5999 + `untaxed_reserves` returns 400 without inserting
- [x] `npx vitest run app/api/bookkeeping/accounts lib/api lib/pending-operations`: 1,095 passed
- [x] Full `npm test`: 22,865 passed. Two unrelated files (peppol transports, booking-templates cron) timed out at 5s under a load average of about 40 from parallel suites on this machine; CI runs them clean.
- [x] `npm run lint` 0 errors, `check:guards` passed, `no-new-type-errors` at baseline 533, `apiskill:check` and `skills:check` up to date

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NHCbdegRu3gC5f8qo6eXsh


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for creating accounts classified as untaxed reserves.
  * Account creation now validates that the account type matches its account class.

* **Bug Fixes**
  * Prevented invalid account type and account class combinations from being submitted.
  * Added clearer validation feedback when account details are inconsistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->